### PR TITLE
Fix approx_rows_to_read calculation

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -88,7 +88,7 @@ class Client(object):
             progress = getattr(packet, 'progress', None)
             if progress:
                 if progress.new_total_rows:
-                    approx_rows_to_read = progress.new_total_rows
+                    approx_rows_to_read += progress.new_total_rows
 
                 rows_read += progress.new_rows
 


### PR DESCRIPTION
I noticed that the total rows returned from the `execute_with_progress` function seemed to be fairly inaccurate vs the builtlin clickhouse client. Comparing the source code it appears that the values returned from progress updates must be summed to get the final result (see [here](https://github.com/yandex/ClickHouse/blob/0d3c4f4d6715cbf9c49114b02664ef16b059030c/dbms/src/IO/Progress.h#L25)).

Simple enough fix, I'm happy to invest some time understanding the tests to bring those up to speed if necessary.