### PR TITLE
Allow for access of final progress stats

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -1,93 +1,10 @@
 from . import errors, defines
 from .block import Block
 from .connection import Connection
-from .progress import Progress
 from .protocol import ServerPacketTypes
+from .result import ProgressQueryResult, QueryResult
 from .util.escape import escape_params
 from .util.helpers import chunks
-
-
-class QueryResult(object):
-    def __init__(
-            self, packet_generator,
-            with_column_types=False, columnar=False):
-        self.packet_generator = packet_generator
-        self.with_column_types = with_column_types
-
-        self.data = []
-        self.columns_with_types = []
-        self.columnar = columnar
-
-        super(QueryResult, self).__init__()
-
-    def store(self, packet):
-        block = getattr(packet, 'block', None)
-        if block is None:
-            return
-
-        # Header block contains no rows. Pick columns from it.
-        if block.rows:
-            if self.columnar:
-                columns = block.get_columns()
-                if self.data:
-                    # Extend corresponding column.
-                    for i, column in enumerate(columns):
-                        self.data[i] += column
-                else:
-                    self.data.extend(columns)
-            else:
-                self.data.extend(block.get_rows())
-
-        elif not self.columns_with_types:
-            self.columns_with_types = block.columns_with_types
-
-    def get_result(self):
-        for packet in self.packet_generator:
-            self.store(packet)
-
-        if self.with_column_types:
-            return self.data, self.columns_with_types
-        else:
-            return self.data
-
-
-class ProgressQueryResult(QueryResult):
-    def __init__(
-            self, packet_generator,
-            with_column_types=False, columnar=False):
-        self.progress_totals = Progress()
-
-        super(ProgressQueryResult, self).__init__(
-            packet_generator, with_column_types, columnar
-        )
-
-    def store_progress(self, progress_packet):
-        self.progress_totals.rows += progress_packet.rows
-        self.progress_totals.bytes += progress_packet.bytes
-        self.progress_totals.total_rows += progress_packet.total_rows
-        return self.progress_totals.rows, self.progress_totals.total_rows
-
-    def __iter__(self):
-        return self
-
-    def next(self):
-        while True:
-            packet = next(self.packet_generator)
-            progress_packet = getattr(packet, 'progress', None)
-            if progress_packet:
-                return self.store_progress(progress_packet)
-            else:
-                self.store(packet)
-
-    # For Python 3.
-    __next__ = next
-
-    def get_result(self):
-        # Read all progress packets.
-        for _ in self:
-            pass
-
-        return super(ProgressQueryResult, self).get_result()
 
 
 class Client(object):

--- a/src/progress.py
+++ b/src/progress.py
@@ -4,16 +4,16 @@ from .reader import read_varint
 
 class Progress(object):
     def __init__(self):
-        self.new_rows = 0
-        self.new_bytes = 0
-        self.new_total_rows = 0
+        self.rows = 0
+        self.bytes = 0
+        self.total_rows = 0
 
         super(Progress, self).__init__()
 
     def read(self, server_revision, fin):
-        self.new_rows = read_varint(fin)
-        self.new_bytes = read_varint(fin)
+        self.rows = read_varint(fin)
+        self.bytes = read_varint(fin)
 
         revision = server_revision
         if revision >= defines.DBMS_MIN_REVISION_WITH_TOTAL_ROWS_IN_PROGRESS:
-            self.new_total_rows = read_varint(fin)
+            self.total_rows = read_varint(fin)

--- a/src/result.py
+++ b/src/result.py
@@ -1,0 +1,84 @@
+from .progress import Progress
+
+
+class QueryResult(object):
+    def __init__(
+            self, packet_generator,
+            with_column_types=False, columnar=False):
+        self.packet_generator = packet_generator
+        self.with_column_types = with_column_types
+
+        self.data = []
+        self.columns_with_types = []
+        self.columnar = columnar
+
+        super(QueryResult, self).__init__()
+
+    def store(self, packet):
+        block = getattr(packet, 'block', None)
+        if block is None:
+            return
+
+        # Header block contains no rows. Pick columns from it.
+        if block.rows:
+            if self.columnar:
+                columns = block.get_columns()
+                if self.data:
+                    # Extend corresponding column.
+                    for i, column in enumerate(columns):
+                        self.data[i] += column
+                else:
+                    self.data.extend(columns)
+            else:
+                self.data.extend(block.get_rows())
+
+        elif not self.columns_with_types:
+            self.columns_with_types = block.columns_with_types
+
+    def get_result(self):
+        for packet in self.packet_generator:
+            self.store(packet)
+
+        if self.with_column_types:
+            return self.data, self.columns_with_types
+        else:
+            return self.data
+
+
+class ProgressQueryResult(QueryResult):
+    def __init__(
+            self, packet_generator,
+            with_column_types=False, columnar=False):
+        self.progress_totals = Progress()
+
+        super(ProgressQueryResult, self).__init__(
+            packet_generator, with_column_types, columnar
+        )
+
+    def store_progress(self, progress_packet):
+        self.progress_totals.rows += progress_packet.rows
+        self.progress_totals.bytes += progress_packet.bytes
+        self.progress_totals.total_rows += progress_packet.total_rows
+        return self.progress_totals.rows, self.progress_totals.total_rows
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        while True:
+            packet = next(self.packet_generator)
+            progress_packet = getattr(packet, 'progress', None)
+            if progress_packet:
+                return self.store_progress(progress_packet)
+            else:
+                self.store(packet)
+
+    # For Python 3.
+    __next__ = next
+
+    def get_result(self):
+        # Read all progress packets.
+        for _ in self:
+            pass
+
+        return super(ProgressQueryResult, self).get_result()

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -65,6 +65,18 @@ class ProgressTestCase(BaseTestCase):
         self.assertEqual(list(progress), [(1, 0)])
         self.assertEqual(progress.get_result(), [(2,)])
 
+    def test_progress_totals(self):
+        progress = self.client.execute_with_progress('SELECT 2')
+        self.assertEqual(progress.progress_totals.rows, 0)
+        self.assertEqual(progress.progress_totals.bytes, 0)
+        self.assertEqual(progress.progress_totals.total_rows, 0)
+
+        self.assertEqual(progress.get_result(), [(2,)])
+
+        self.assertEqual(progress.progress_totals.rows, 1)
+        self.assertEqual(progress.progress_totals.bytes, 1)
+        self.assertEqual(progress.progress_totals.total_rows, 0)
+
     def test_select_with_progress_error(self):
         with self.assertRaises(ServerException):
             progress = self.client.execute_with_progress('SELECT error')


### PR DESCRIPTION
This refactors some of the logic around the processing of progress
packets so that the final (sum) of progress counters is accessible. It
includes the following changes:

- make QueryResult know how to process and `store()` its own packets.
- Make ProgressQueryResult class a subclass of QueryResult.
- ProgressQueryResult can process progress packets.
- Less encapsulation breakage (Client reaching into QueryResult objects)
- Client now provides generator of packets to QueryResult to iterate on
- ProgressQueryResult now aggregates bytes as well as rows (although
bytes are not returned in the generator to preserve the current
interface)
- Final sum of progress counters is accessible as `progress_totals`