### PR TITLE
added option to retrieve profile info about the last query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Option to access profile info about the last executed query.
 
 ## [0.0.15] - 2018-09-26
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -306,6 +306,14 @@ You can turn it on by *types_check* option:
 
         client.execute('INSERT INTO test (x) VALUES', [('abc', )], types_check=True)
 
+Accessing `ProfileInfo` of the last query (e.g. to read `rows_before_limit`):
+
+    .. code-block:: python
+
+        rows = client.execute('SELECT * FROM test ORDER BY foo LIMIT 5')
+        total_rows_count = client.last_query.profile_info.rows_before_limit
+
+
 License
 =======
 

--- a/clickhouse_driver/client.py
+++ b/clickhouse_driver/client.py
@@ -2,7 +2,9 @@ from . import errors, defines
 from .block import Block
 from .connection import Connection
 from .protocol import ServerPacketTypes
-from .result import IterQueryResult, ProgressQueryResult, QueryResult
+from .result import (
+    IterQueryResult, ProgressQueryResult, QueryResult, QueryInfo
+)
 from .util.escape import escape_params
 from .util.helpers import chunks
 
@@ -28,10 +30,14 @@ class Client(object):
         self.connection = Connection(*args, **kwargs)
         self.connection.context.settings = self.settings
         self.connection.context.client_settings = self.client_settings
+        self.reset_last_query()
         super(Client, self).__init__()
 
     def disconnect(self):
         self.connection.disconnect()
+
+    def reset_last_query(self):
+        self.last_query = None
 
     def receive_result(self, with_column_types=False, progress=False,
                        columnar=False):
@@ -93,6 +99,10 @@ class Client(object):
         elif packet.type == ServerPacketTypes.EXTREMES:
             return packet
 
+        elif packet.type == ServerPacketTypes.PROFILE_INFO:
+            self.last_query.store(packet)
+            return True
+
         else:
             return True
 
@@ -118,6 +128,7 @@ class Client(object):
 
         self.make_query_settings(settings)
         self.connection.force_connect()
+        self.last_query = QueryInfo()
 
         try:
             # INSERT queries can use list or tuple of list/tuples/dicts.
@@ -139,6 +150,7 @@ class Client(object):
 
         except Exception:
             self.disconnect()
+            self.reset_last_query()
             raise
 
     def execute_with_progress(
@@ -148,6 +160,7 @@ class Client(object):
 
         self.make_query_settings(settings)
         self.connection.force_connect()
+        self.last_query = QueryInfo()
 
         try:
             return self.process_ordinary_query_with_progress(
@@ -158,6 +171,7 @@ class Client(object):
 
         except Exception:
             self.disconnect()
+            self.reset_last_query()
             raise
 
     def execute_iter(
@@ -167,6 +181,7 @@ class Client(object):
 
         self.make_query_settings(settings)
         self.connection.force_connect()
+        self.last_query = QueryInfo()
 
         try:
             return self.iter_process_ordinary_query(
@@ -176,7 +191,8 @@ class Client(object):
             )
 
         except Exception:
-            self.connection.disconnect()
+            self.disconnect()
+            self.reset_last_query()
             raise
 
     def process_ordinary_query_with_progress(

--- a/clickhouse_driver/client.py
+++ b/clickhouse_driver/client.py
@@ -35,6 +35,7 @@ class Client(object):
 
     def disconnect(self):
         self.connection.disconnect()
+        self.reset_last_query()
 
     def reset_last_query(self):
         self.last_query = None
@@ -100,7 +101,7 @@ class Client(object):
             return packet
 
         elif packet.type == ServerPacketTypes.PROFILE_INFO:
-            self.last_query.store(packet)
+            self.last_query.store_profile(packet)
             return True
 
         else:
@@ -150,7 +151,6 @@ class Client(object):
 
         except Exception:
             self.disconnect()
-            self.reset_last_query()
             raise
 
     def execute_with_progress(
@@ -171,7 +171,6 @@ class Client(object):
 
         except Exception:
             self.disconnect()
-            self.reset_last_query()
             raise
 
     def execute_iter(
@@ -192,7 +191,6 @@ class Client(object):
 
         except Exception:
             self.disconnect()
-            self.reset_last_query()
             raise
 
     def process_ordinary_query_with_progress(

--- a/clickhouse_driver/result.py
+++ b/clickhouse_driver/result.py
@@ -1,5 +1,4 @@
 from .progress import Progress
-from .protocol import ServerPacketTypes
 
 
 class QueryResult(object):
@@ -120,6 +119,5 @@ class QueryInfo(object):
     def __init__(self):
         self.profile_info = None
 
-    def store(self, packet):
-        if packet.type == ServerPacketTypes.PROFILE_INFO:
-            self.profile_info = packet.profile_info
+    def store_profile(self, packet):
+        self.profile_info = packet.profile_info

--- a/clickhouse_driver/result.py
+++ b/clickhouse_driver/result.py
@@ -1,4 +1,5 @@
 from .progress import Progress
+from .protocol import ServerPacketTypes
 
 
 class QueryResult(object):
@@ -113,3 +114,12 @@ class IterQueryResult(object):
 
     # For Python 3.
     __next__ = next
+
+
+class QueryInfo(object):
+    def __init__(self):
+        self.profile_info = None
+
+    def store(self, packet):
+        if packet.type == ServerPacketTypes.PROFILE_INFO:
+            self.profile_info = packet.profile_info

--- a/tests/test_query_info.py
+++ b/tests/test_query_info.py
@@ -42,10 +42,8 @@ class QueryInfoTestCase(BaseTestCase):
     def test_store_profile_info_after_execute_with_progress(self):
         with self.sample_table():
             progress = self.client.execute_with_progress(self.sample_query)
-            for num_rows, total_rows in progress:
-                pass
-            else:
-                progress.get_result()
+            list(progress)
+            progress.get_result()
 
         last_query = self.client.last_query
         assert last_query is not None

--- a/tests/test_query_info.py
+++ b/tests/test_query_info.py
@@ -1,0 +1,76 @@
+from contextlib import contextmanager
+
+from clickhouse_driver import errors
+from tests.testcase import BaseTestCase
+
+
+class QueryInfoTestCase(BaseTestCase):
+
+    @property
+    def sample_query(self):
+        return 'SELECT * FROM test ORDER BY foo DESC LIMIT 5'
+
+    @contextmanager
+    def sample_table(self):
+        with self.create_table('foo UInt8'):
+            self.client.execute('INSERT INTO test (foo) VALUES',
+                                [(i,) for i in range(42)])
+            self.client.reset_last_query()
+            yield
+
+    def test_default_value(self):
+        assert self.client.last_query is None
+
+    def test_store_profile_info_after_execute(self):
+        with self.sample_table():
+            self.client.execute(self.sample_query)
+
+        last_query = self.client.last_query
+        assert last_query is not None
+        assert last_query.profile_info is not None
+        assert last_query.profile_info.rows_before_limit == 42
+
+    def test_store_profile_info_after_execute_iter(self):
+        with self.sample_table():
+            list(self.client.execute_iter(self.sample_query))
+
+        last_query = self.client.last_query
+        assert last_query is not None
+        assert last_query.profile_info is not None
+        assert last_query.profile_info.rows_before_limit == 42
+
+    def test_store_profile_info_after_execute_with_progress(self):
+        with self.sample_table():
+            progress = self.client.execute_with_progress(self.sample_query)
+            for num_rows, total_rows in progress:
+                pass
+            else:
+                progress.get_result()
+
+        last_query = self.client.last_query
+        assert last_query is not None
+        assert last_query.profile_info is not None
+        assert last_query.profile_info.rows_before_limit == 42
+
+    def test_override_after_subsequent_queries(self):
+        query = 'SELECT * FROM test WHERE foo < %(i)s ORDER BY foo LIMIT 5'
+        with self.sample_table():
+            for i in range(1, 10):
+                self.client.execute(query, {'i': i})
+
+                profile_info = self.client.last_query.profile_info
+                assert profile_info.rows_before_limit == i
+
+    def test_reset_last_query(self):
+        with self.sample_table():
+            self.client.execute(self.sample_query)
+
+        assert self.client.last_query is not None
+        self.client.reset_last_query()
+        assert self.client.last_query is None
+
+    def test_reset_on_query_error(self):
+        with self.assertRaises(errors.ServerException):
+            self.client.execute('SELECT answer FROM universe')
+
+        assert self.client.last_query is None


### PR DESCRIPTION
As discussed in https://github.com/mymarilyn/clickhouse-driver/issues/55, adds a way to access ```ProfileInfo``` of the last executed query.