### PR TITLE
Fix null value on bytestring columns

### DIFF
--- a/clickhouse_driver/columns/stringcolumn.py
+++ b/clickhouse_driver/columns/stringcolumn.py
@@ -10,12 +10,13 @@ from codecs import utf_8_decode, utf_8_encode
 class String(Column):
     ch_type = 'String'
     py_types = compat.string_types
+    null_value = ''
 
     # TODO: pass user encoding here
 
     def prepare_null(self, value):
         if self.nullable and value is None:
-            return '', True
+            return self.null_value, True
 
         else:
             return value, False
@@ -34,6 +35,7 @@ class String(Column):
 
 class ByteString(String):
     py_types = (bytearray, bytes)
+    null_value = b''
 
     def write_items(self, items, buf):
         for value in items:
@@ -93,6 +95,7 @@ class FixedString(String):
 
 class ByteFixedString(FixedString):
     py_types = (bytearray, bytes)
+    null_value = b''
 
     def read_items(self, n_items, buf):
         length = self.length

--- a/tests/columns/test_fixedstring.py
+++ b/tests/columns/test_fixedstring.py
@@ -129,3 +129,25 @@ class ByteFixedStringTestCase(BaseTestCase):
             )
             self.assertIsInstance(inserted[0][0], bytes)
             self.assertIsInstance(inserted[1][0], bytes)
+
+    def test_nullable(self):
+        with self.create_table('a Nullable(FixedString(10))'):
+            data = [
+                (None, ),
+                (b'test\x00\x00\x00\x00\x00\x00', ),
+                (None, ),
+                (b'nullable\x00\x00', )
+            ]
+            self.client.execute(
+                'INSERT INTO test (a) VALUES', data
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(
+                inserted,
+                '\\N\ntest\\0\\0\\0\\0\\0\\0\n\\N\nnullable\\0\\0\n'
+            )
+
+            inserted = self.client.execute(query)
+            self.assertEqual(inserted, data)

--- a/tests/columns/test_string.py
+++ b/tests/columns/test_string.py
@@ -103,3 +103,17 @@ class ByteStringTestCase(BaseTestCase):
                 )
 
                 self.assertIn('Column a', str(e.exception))
+
+    def test_nullable(self):
+        with self.create_table('a Nullable(String)'):
+            data = [(None, ), (b'test', ), (None, ), (b'nullable', )]
+            self.client.execute(
+                'INSERT INTO test (a) VALUES', data
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(inserted, '\\N\ntest\n\\N\nnullable\n')
+
+            inserted = self.client.execute(query)
+            self.assertEqual(inserted, data)


### PR DESCRIPTION
When client setting `strings_as_bytes` is set, the driver crashes when inserting `None` values into columns with type `Nullable([Fixed]String)`:

```
  File "clickhouse_driver/client.py", line 142, in execute
    query_id=query_id, types_check=types_check
  File "clickhouse_driver/client.py", line 246, in process_insert_query
    self.send_data(sample_block, data, types_check=types_check)
  File "clickhouse_driver/client.py", line 270, in send_data
    self.connection.send_data(block)
  File "clickhouse_driver/connection.py", line 429, in send_data
    self.block_out.write(block)
  File "clickhouse_driver/streams/native.py", line 41, in write
    self.fout, types_check=block.types_check)
  File "clickhouse_driver/columns/service.py", line 84, in write_column
    column.write_data(items, buf)
  File "clickhouse_driver/columns/base.py", line 79, in write_data
    self._write_data(items, buf)
  File "clickhouse_driver/columns/base.py", line 83, in _write_data
    self.write_items(prepared, buf)
  File "clickhouse_driver/columns/stringcolumn.py", line 120, in write_items
    items_buf_view[buf_pos:buf_pos + min(length, value_len)] = value
TypeError: a bytes-like object is required, not 'str'
```

This is likely because the method `ByteString.prepare_null` is simply `String.prepare_null`, and returns the empty string `''` instead the empty bytes `b''`.
I've been able to fix it with this PR, but I'm not familiar at all with this project so maybe it's not the right way to do it. Let me know if I can help :)