### PR TITLE
Enum option parsing is not handling all supported characters correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm project settings
+.idea/

--- a/clickhouse_driver/columns/enumcolumn.py
+++ b/clickhouse_driver/columns/enumcolumn.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Dict
 
 from .. import errors
 from ..util import compat
@@ -64,7 +63,7 @@ def create_enum_column(spec, column_options):
     return cls(Enum(cls.ch_type, _parse_options(params)), **column_options)
 
 
-def _parse_options(option_string: str) -> Dict[str, int]:
+def _parse_options(option_string):
     options = dict()
     after_name = False
     escaped = False

--- a/clickhouse_driver/columns/enumcolumn.py
+++ b/clickhouse_driver/columns/enumcolumn.py
@@ -4,8 +4,6 @@ from .. import errors
 from ..util import compat
 from .intcolumn import IntColumn
 
-OPTION_NAME_QUOTES = ("'",)  # Quotes when parsing options
-
 
 class EnumColumn(IntColumn):
     py_types = (Enum, ) + compat.integer_types + compat.string_types
@@ -80,7 +78,7 @@ def _parse_options(option_string):
             if ch in (' ', '='):
                 pass
             elif ch == ',':
-                options.setdefault(name, int(value))
+                options[name] = int(value)
                 after_name = False
                 name = ''
                 value = ''  # reset before collecting new option
@@ -97,7 +95,7 @@ def _parse_options(option_string):
                 name += ch
 
         else:
-            if ch in OPTION_NAME_QUOTES:
+            if ch == "'":
                 quote_character = ch
 
     if after_name:

--- a/clickhouse_driver/columns/enumcolumn.py
+++ b/clickhouse_driver/columns/enumcolumn.py
@@ -1,8 +1,11 @@
 from enum import Enum
+from typing import Dict
 
 from .. import errors
 from ..util import compat
 from .intcolumn import IntColumn
+
+OPTION_NAME_QUOTES = ("'",)  # Quotes when parsing options
 
 
 class EnumColumn(IntColumn):
@@ -22,7 +25,6 @@ class EnumColumn(IntColumn):
                 return enum_cls[source_value].value
             else:
                 return enum_cls(source_value).value
-
         except (ValueError, KeyError):
             choices = ', '.join(
                 "'{}' = {}".format(x.name, x.value) for x in enum_cls
@@ -58,11 +60,47 @@ def create_enum_column(spec, column_options):
         params = spec[7:-1]
         cls = Enum16Column
 
-    d = {}
-    for param in params.split(", '"):
-        pos = param.rfind("'")
-        name = param[:pos].lstrip("'")
-        value = int(param[pos + 1:].lstrip(' ='))
-        d[name] = value
+    return cls(Enum(cls.ch_type, _parse_options(params)), **column_options)
 
-    return cls(Enum(cls.ch_type, d), **column_options)
+
+def _parse_options(option_string: str) -> Dict[str, int]:
+    options = dict()
+    after_name = False
+    escaped = False
+    quote_character = None
+    name = ''
+    value = ''
+
+    for ch in option_string:
+        if escaped:
+            name += ch
+            escaped = False  # accepting escaped character
+
+        elif after_name:
+            if ch in (' ', '='):
+                pass
+            elif ch == ',':
+                options.setdefault(name, int(value))
+                after_name = False
+                name = ''
+                value = ''  # reset before collecting new option
+            else:
+                value += ch
+
+        elif quote_character:
+            if ch == '\\':
+                escaped = True
+            elif ch == quote_character:
+                quote_character = None
+                after_name = True  # start collecting option value
+            else:
+                name += ch
+
+        else:
+            if ch in OPTION_NAME_QUOTES:
+                quote_character = ch
+
+    if after_name:
+        options.setdefault(name, int(value))  # append word after last comma
+
+    return options

--- a/clickhouse_driver/columns/enumcolumn.py
+++ b/clickhouse_driver/columns/enumcolumn.py
@@ -27,7 +27,8 @@ class EnumColumn(IntColumn):
                 return enum_cls(source_value).value
         except (ValueError, KeyError):
             choices = ', '.join(
-                "'{}' = {}".format(x.name, x.value) for x in enum_cls
+                "'{}' = {}".format(x.name.replace("'", r"\'"), x.value)
+                for x in enum_cls
             )
             enum_str = '{}({})'.format(enum_cls.__name__, choices)
 

--- a/tests/columns/test_enum.py
+++ b/tests/columns/test_enum.py
@@ -85,7 +85,7 @@ class EnumTestCase(BaseTestCase):
 
     def test_quote_in_name(self):
         columns = "a Enum8(' \\' t = ' = -1, 'test' = 2)"
-        data = [(-1, ), (" \\' t = ", )]
+        data = [(-1, ), (" ' t = ", )]
         with self.create_table(columns):
             self.client.execute(
                 'INSERT INTO test (a) VALUES', data
@@ -101,7 +101,28 @@ class EnumTestCase(BaseTestCase):
             )
 
             inserted = self.client.execute(query)
-            self.assertEqual(inserted, [(" \\' t = ", ), (" \\' t = ", )])
+            self.assertEqual(inserted, [(" ' t = ", ), (" ' t = ", )])
+
+    def test_comma_and_space_in_name(self):
+        columns = "a Enum8('one' = 1, 'two_with_comma, ' = 2, 'three' = 3)"
+        data = [(2, ), ('two_with_comma, ', )]
+        with self.create_table(columns):
+            self.client.execute(
+                'INSERT INTO test (a) VALUES', data
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+
+            self.assertEqual(
+                inserted, (
+                    'two_with_comma, \n'
+                    'two_with_comma, \n'
+                )
+            )
+
+            inserted = self.client.execute(query)
+            self.assertEqual(inserted, [('two_with_comma, ', ), ('two_with_comma, ', )])
 
     def test_nullable(self):
         columns = "a Nullable(Enum8('hello' = -1, 'world' = 2))"

--- a/tests/columns/test_enum.py
+++ b/tests/columns/test_enum.py
@@ -122,7 +122,9 @@ class EnumTestCase(BaseTestCase):
             )
 
             inserted = self.client.execute(query)
-            self.assertEqual(inserted, [('two_with_comma, ', ), ('two_with_comma, ', )])
+            self.assertEqual(
+                inserted, [('two_with_comma, ',), ('two_with_comma, ',)]
+            )
 
     def test_nullable(self):
         columns = "a Nullable(Enum8('hello' = -1, 'world' = 2))"


### PR DESCRIPTION
When querying a table with `Enum` options containing comma and a space, the parsing of the options fails (see below).

With an example table as
```
CREATE TABLE default.test_table (
	id UInt64,  
	datetime DateTime,  
	action_type Enum8('first' = 1, 'test_rename = 3, ' = 2, 'dele\'te' = 3, 'to"uch' = 4)
) ENGINE = MergeTree
```
the options are a bit non-standard but seem to be actually permitted. (Kind of created these options by accident due to a typo in a query and then figured out that the parsing could be improved on this.)

And while testing the the original parsing, I've also noticed that it is not really handling any empty characters before the first option; it gets prepended into the first option, e.g., `Enum8(  'one' = 1, 'exa"mple' = 2, 'three' = 3)` is turned into `{"  'one": 1, 'exa"mple': 2, 'three': 3}` which doesn't seem right either.

```
Traceback (most recent call last):
  File "/home/.../test_clickhouse_integration.py", line 92, in <module>
    .limit(5)
  File "/home/.../venv/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 2843, in all
    return list(self)
  File "/home/.../venv/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 2995, in __iter__
    return self._execute_and_instances(context)
  File "/home/.../venv/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 3018, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/home/.../venv/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 948, in execute
    return meth(self, multiparams, params)
  File "/home/.../venv/lib/python3.6/site-packages/sqlalchemy/sql/elements.py", line 269, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/home/.../venv/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1060, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/home/.../venv/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1200, in _execute_context
    context)
  File "/home/.../venv/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1416, in _handle_dbapi_exception
    util.reraise(*exc_info)
  File "/home/.../venv/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 249, in reraise
    raise value
  File "/home/.../venv/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1193, in _execute_context
    context)
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_sqlalchemy/drivers/base.py", line 492, in do_execute
    cursor.execute(statement, parameters, context=context)
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_sqlalchemy/drivers/native/connector.py", line 125, in execute
    external_tables=external_tables, settings=settings
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/client.py", line 119, in execute
    columnar=columnar
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/client.py", line 192, in process_ordinary_query
    columnar=columnar)
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/client.py", line 42, in receive_result
    return result.get_result()
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/result.py", line 39, in get_result
    for packet in self.packet_generator:
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/client.py", line 54, in packet_generator
    packet = self.receive_packet()
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/client.py", line 68, in receive_packet
    packet = self.connection.receive_packet()
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/connection.py", line 334, in receive_packet
    packet.block = self.receive_data()
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/connection.py", line 393, in receive_data
    block = self.block_in.read()
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/streams/native.py", line 80, in read
    self.fin)
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/columns/service.py", line 67, in read_column
    column = get_column_by_spec(column_spec, column_options=column_options)
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/columns/service.py", line 45, in get_column_by_spec
    return create_enum_column(spec, column_options)
  File "/home/.../venv/lib/python3.6/site-packages/clickhouse_driver/columns/enumcolumn.py", line 65, in create_enum_column
    value = int(param[pos + 1:].lstrip(' ='))
ValueError: invalid literal for int() with base 10: 'test_rename = 3'
```

Do you agree that it make sense to fix the options parsing? Should I add some tests for it?

In addition I've added escaping of single quotes into generated error message.