### PR TITLE
Add max_partitions_per_insert_block to settings.available

### DIFF
--- a/clickhouse_driver/settings/available.py
+++ b/clickhouse_driver/settings/available.py
@@ -24,6 +24,7 @@ settings = {
     'max_insert_block_size': SettingUInt64,
     'min_insert_block_size_rows': SettingUInt64,
     'min_insert_block_size_bytes': SettingUInt64,
+    'max_partitions_per_insert_block': SettingUInt64,
     'max_threads': SettingMaxThreads,
     'max_read_buffer_size': SettingUInt64,
     'max_distributed_connections': SettingUInt64,


### PR DESCRIPTION
The `max_partitions_per_insert_block` is defined in:
https://github.com/yandex/ClickHouse/blob/f566182582c70986be19777b3583c803607928ad/dbms/src/Core/Settings.h#L315

Regarding the data type, I have submitted the pull request https://github.com/yandex/ClickHouse/pull/5028 because it is used in other places of code as `size_t`, rather than `boolean`.