### PR TITLE
fallback for os_name if user name is not defined

### DIFF
--- a/clickhouse_driver/clientinfo.py
+++ b/clickhouse_driver/clientinfo.py
@@ -36,7 +36,10 @@ class ClientInfo(object):
     def __init__(self, client_name):
         self.query_kind = ClientInfo.QueryKind.NO_QUERY
 
-        self.os_user = getpass.getuser()
+        try:
+            self.os_user = getpass.getuser()
+        except KeyError:
+            self.os_user = ''
         self.client_hostname = socket.gethostname()
         self.client_name = client_name
 


### PR DESCRIPTION
got this error while running inside docker container (no user entry for such uid)

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/clickhouse_driver/client.py", line 119, in execute
    columnar=columnar
  File "/usr/local/lib/python3.7/site-packages/clickhouse_driver/client.py", line 188, in process_ordinary_query
    self.connection.send_query(query, query_id=query_id)
  File "/usr/local/lib/python3.7/site-packages/clickhouse_driver/connection.py", line 432, in send_query
    client_info = ClientInfo(self.client_name)
  File "/usr/local/lib/python3.7/site-packages/clickhouse_driver/clientinfo.py", line 38, in __init__
    self.os_user = getpass.getuser()
  File "/usr/local/lib/python3.7/getpass.py", line 169, in getuser
    return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 1001'
```