### PR TITLE
feat: support datetime str and date str

### DIFF
--- a/clickhouse_driver/columns/datecolumn.py
+++ b/clickhouse_driver/columns/datecolumn.py
@@ -1,5 +1,7 @@
 from datetime import date, timedelta
 
+from dateutil.parser import parser
+
 from .base import FormatColumn
 
 
@@ -13,7 +15,13 @@ class DateColumn(FormatColumn):
 
     def before_write_item(self, value):
         if type(value) != date:
-            value = date(value.year, value.month, value.day)
+            if isinstance(value, str):
+                # support date/datetime str, keep in touch with
+                # datetime parsing in clickhouse/mysql/hive
+                datetime_parser = parser()
+                value = datetime_parser.parse(value).date()
+            else:
+                value = date(value.year, value.month, value.day)
 
         diff = (value - self.epoch_start).days
         if value > self.epoch_end or diff < 0:

--- a/clickhouse_driver/columns/datetimecolumn.py
+++ b/clickhouse_driver/columns/datetimecolumn.py
@@ -1,6 +1,7 @@
 from calendar import timegm
 from datetime import datetime
 from time import mktime
+from dateutil.parser import parser
 
 from pytz import timezone as get_timezone, utc
 
@@ -25,6 +26,12 @@ class DateTimeColumn(FormatColumn):
             # support supplying raw integers to avoid
             # costly timezone conversions when using datetime
             return value
+
+        if isinstance(value, str):
+            # support date/datetime str, keep in touch with
+            # datetime parsing in clickhouse/mysql/hive
+            datetime_parser = parser()
+            value = datetime_parser.parse(value)
 
         if self.timezone:
             # Set server's timezone for offset-naive datetime.

--- a/tests/columns/test_date.py
+++ b/tests/columns/test_date.py
@@ -44,3 +44,13 @@ class DateTestCase(BaseTestCase):
             query = 'SELECT * FROM test'
             inserted = self.emit_cli(query)
             self.assertEqual(inserted, '0000-00-00\n0000-00-00\n')
+
+    def test_insert_date_str_to_date(self):
+        with self.create_table('a Date'):
+            testTimeStr = '2019-07-02'
+            self.client.execute(
+                'INSERT INTO test (a) VALUES', [(testTimeStr, )]
+            )
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(inserted, '2019-07-02\n')

--- a/tests/columns/test_datetime.py
+++ b/tests/columns/test_datetime.py
@@ -12,18 +12,24 @@ from tests.util import require_server_version
 
 class DateTimeTestCase(BaseTestCase):
     def test_simple(self):
-        with self.create_table('a Date, b DateTime'):
-            data = [(date(2012, 10, 25), datetime(2012, 10, 25, 14, 7, 19))]
+        with self.create_table('a Date, b DateTime, c DateTime'):
+            data = [(date(2012, 10, 25),
+                     datetime(2012, 10, 25, 14, 7, 19),
+                     '2019-07-02 11:47:20')]
             self.client.execute(
-                'INSERT INTO test (a, b) VALUES', data
+                'INSERT INTO test (a, b, c) VALUES', data
             )
 
             query = 'SELECT * FROM test'
             inserted = self.emit_cli(query)
-            self.assertEqual(inserted, '2012-10-25\t2012-10-25 14:07:19\n')
+            self.assertEqual(
+                inserted,
+                '2012-10-25\t2012-10-25 14:07:19\t2019-07-02 11:47:20\n')
 
             inserted = self.client.execute(query)
-            self.assertEqual(inserted, data)
+
+            self.assertEqual(inserted[0][:2], data[0][:2])
+            self.assertEqual(inserted[0][2], datetime(2019, 7, 2, 11, 47, 20))
 
     def test_nullable_date(self):
         with self.create_table('a Nullable(Date)'):


### PR DESCRIPTION
In many cases, I use clickhouse-driver insert date and datetime string to clickhouse directly, and then 
I get these errors as below:
```
AttributeError: 'str' object has no attribute 'year'
or
AttributeError: 'str' object has no attribute 'tzinfo'
```
the former error occur In DateColumn class:
```
    def before_write_item(self, value):
        if type(value) != date:
            value = date(value.year, value.month, value.day)

        diff = (value - self.epoch_start).days
        if value > self.epoch_end or diff < 0:
            return 0
        return diff
```
the latter error occur in DateTimeColumn class:
```
        if self.timezone:
            # Set server's timezone for offset-naive datetime.
            if value.tzinfo is None:
                value = self.timezone.localize(value)

            value = value.astimezone(utc)
            return int(timegm(value.timetuple()))
```
In common practice, clickhouse/hive/mysql all support identifying date or datetime string. for example:
```
insert into wikistat values ('2019-07-01', '2019-07-01 12:00:00', 'acac', 'aaa-bbb', '/aaa');
```
the first column in wikistat is Date and the second column in wikistat is DateTime. This sql works well in clickhouse.
In pyhive, an python client for hive, they solve this problem by this way:
```
_TIMESTAMP_PATTERN = re.compile(r'(\d+-\d+-\d+ \d+:\d+:\d+(\.\d{,6})?)')


def _parse_timestamp(value):
    if value:
        match = _TIMESTAMP_PATTERN.match(value)
        if match:
            if match.group(2):
                format = '%Y-%m-%d %H:%M:%S.%f'
                # use the pattern to truncate the value
                value = match.group()
            else:
                format = '%Y-%m-%d %H:%M:%S'
            value = datetime.datetime.strptime(value, format)
        else:
            raise Exception(
                'Cannot convert "{}" into a datetime'.format(value))
    else:
        value = None
    return value
```
So, I think this improvment is necessary, otherwise, I have to transfer datetime string to datetime in advance. For a large quantity of date/datetime columns, it'll be a disaster.
Please review, Thanks