### PR TITLE
Expose columnar to  execute_with_progress

### DIFF
--- a/clickhouse_driver/client.py
+++ b/clickhouse_driver/client.py
@@ -223,7 +223,7 @@ class Client(object):
     def execute_with_progress(
             self, query, params=None, with_column_types=False,
             external_tables=None, query_id=None, settings=None,
-            types_check=False):
+            types_check=False, columnar=False):
         """
         Executes SELECT query with progress information.
         See, :ref:`execute-with-progress`.
@@ -244,6 +244,9 @@ class Client(object):
                          Defaults to ``None`` (no additional settings).
         :param types_check: enables type checking of data for INSERT queries.
                             Causes additional overhead. Defaults to ``False``.
+        :param columnar: if specified the result will be returned in
+                         column-oriented form.
+                         Defaults to ``False`` (row-like form).
         :return: :ref:`progress-query-result` proxy.
         """
 
@@ -254,8 +257,8 @@ class Client(object):
         try:
             return self.process_ordinary_query_with_progress(
                 query, params=params, with_column_types=with_column_types,
-                external_tables=external_tables,
-                query_id=query_id, types_check=types_check
+                external_tables=external_tables, query_id=query_id,
+                types_check=types_check, columnar=columnar
             )
 
         except Exception:

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -145,6 +145,16 @@ class IteratorTestCase(BaseTestCase):
 
         self.assertFalse(self.client.connection.connected)
 
+    def test_select_with_columar_with_column_types(self):
+        progress = self.client.execute_with_progress(
+            'SELECT arrayJoin(A) -1 as j,'
+            'arrayJoin(A)+1 as k FROM('
+            'SELECT range(3) as A)',
+            columnar=True, with_column_types=True)
+        rv = ([(-1, 0, 1), (1, 2, 3)], [('j', 'Int16'), ('k', 'UInt16')])
+        self.assertEqual(progress.get_result(), rv)
+        self.assertTrue(self.client.connection.connected)
+
 
 class LogTestCase(BaseTestCase):
     @require_server_version(18, 12, 13)


### PR DESCRIPTION
Right now there is no way to set columnar  in execute_with_progress. It seems all it was missing was to expose the parameter.