### PR TITLE
Set allow_suspicious_low_cardinality_types for LowCardinality tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 env:
-  - VERSION=19.8.3.8 # SimpleAggregateFunction
+  - VERSION=19.15.3.6  # latest
+  - VERSION=19.9.2.4   # allow_suspicious_low_cardinality_types
+  - VERSION=19.8.3.8   # SimpleAggregateFunction
   - VERSION=19.3.3
   - VERSION=18.12.17
   - VERSION=18.12.13

--- a/tests/columns/test_low_cardinality.py
+++ b/tests/columns/test_low_cardinality.py
@@ -6,9 +6,18 @@ from tests.util import require_server_version
 
 
 class LowCardinalityTestCase(BaseTestCase):
+    stable_support_version = (19, 9, 2)
+
+    def cli_client_kwargs(self):
+        current = self.client.connection.server_info.version_tuple()
+        if current >= self.stable_support_version:
+            return {'allow_suspicious_low_cardinality_types': 1}
+        return {}
+
     @require_server_version(19, 3, 3)
     def test_uint8(self):
-        with self.create_table('a LowCardinality(UInt8)'):
+        with self.create_table('a LowCardinality(UInt8)',
+                **self.cli_client_kwargs()):
             data = [(x, ) for x in range(255)]
             self.client.execute('INSERT INTO test (a) VALUES', data)
 
@@ -24,7 +33,8 @@ class LowCardinalityTestCase(BaseTestCase):
 
     @require_server_version(19, 3, 3)
     def test_int8(self):
-        with self.create_table('a LowCardinality(Int8)'):
+        with self.create_table('a LowCardinality(Int8)',
+                **self.cli_client_kwargs()):
             data = [(x - 127, ) for x in range(255)]
             self.client.execute('INSERT INTO test (a) VALUES', data)
 
@@ -41,7 +51,8 @@ class LowCardinalityTestCase(BaseTestCase):
 
     @require_server_version(19, 3, 3)
     def test_nullable_int8(self):
-        with self.create_table('a LowCardinality(Nullable(Int8))'):
+        with self.create_table('a LowCardinality(Nullable(Int8))',
+                **self.cli_client_kwargs()):
             data = [(None, ), (-1, ), (0, ), (1, ), (None, )]
             self.client.execute('INSERT INTO test (a) VALUES', data)
 
@@ -54,7 +65,8 @@ class LowCardinalityTestCase(BaseTestCase):
 
     @require_server_version(19, 3, 3)
     def test_date(self):
-        with self.create_table('a LowCardinality(Date)'):
+        with self.create_table('a LowCardinality(Date)',
+                **self.cli_client_kwargs()):
             start = date(1970, 1, 1)
             data = [(start + timedelta(x), ) for x in range(300)]
             self.client.execute('INSERT INTO test (a) VALUES', data)
@@ -65,7 +77,8 @@ class LowCardinalityTestCase(BaseTestCase):
 
     @require_server_version(19, 3, 3)
     def test_float(self):
-        with self.create_table('a LowCardinality(Float)'):
+        with self.create_table('a LowCardinality(Float)',
+                **self.cli_client_kwargs()):
             data = [(float(x),) for x in range(300)]
             self.client.execute('INSERT INTO test (a) VALUES', data)
 
@@ -75,7 +88,8 @@ class LowCardinalityTestCase(BaseTestCase):
 
     @require_server_version(19, 3, 3)
     def test_decimal(self):
-        with self.create_table('a LowCardinality(Float)'):
+        with self.create_table('a LowCardinality(Float)',
+                **self.cli_client_kwargs()):
             data = [(Decimal(x),) for x in range(300)]
             self.client.execute('INSERT INTO test (a) VALUES', data)
 
@@ -85,7 +99,8 @@ class LowCardinalityTestCase(BaseTestCase):
 
     @require_server_version(19, 3, 3)
     def test_array(self):
-        with self.create_table('a Array(LowCardinality(Int16))'):
+        with self.create_table('a Array(LowCardinality(Int16))',
+                **self.cli_client_kwargs()):
             data = [((100, 500), )]
             self.client.execute('INSERT INTO test (a) VALUES', data)
 
@@ -98,7 +113,8 @@ class LowCardinalityTestCase(BaseTestCase):
 
     @require_server_version(19, 3, 3)
     def test_empty_array(self):
-        with self.create_table('a Array(LowCardinality(Int16))'):
+        with self.create_table('a Array(LowCardinality(Int16))',
+                **self.cli_client_kwargs()):
             data = [(tuple(), )]
             self.client.execute('INSERT INTO test (a) VALUES', data)
 
@@ -111,7 +127,8 @@ class LowCardinalityTestCase(BaseTestCase):
 
     @require_server_version(19, 3, 3)
     def test_string(self):
-        with self.create_table('a LowCardinality(String)'):
+        with self.create_table('a LowCardinality(String)',
+                **self.cli_client_kwargs()):
             data = [
                 ('test', ), ('low', ), ('cardinality', ),
                 ('test', ), ('test', ), ('', )
@@ -130,7 +147,8 @@ class LowCardinalityTestCase(BaseTestCase):
 
     @require_server_version(19, 3, 3)
     def test_fixed_string(self):
-        with self.create_table('a LowCardinality(FixedString(12))'):
+        with self.create_table('a LowCardinality(FixedString(12))',
+                **self.cli_client_kwargs()):
             data = [
                 ('test', ), ('low', ), ('cardinality', ),
                 ('test', ), ('test', ), ('', )


### PR DESCRIPTION
This setting has been introduced in v19.9.2.4-stable (all previous tags
marked as -testing, so I think they should be skipped).

Refs: ClickHouse/ClickHouse@4819a3439451ea69fb2a3a8779c003a137c07e59
Refs: ClickHouse/ClickHouse#5448