### PR TITLE
insert columnar data

### DIFF
--- a/clickhouse_driver/block.py
+++ b/clickhouse_driver/block.py
@@ -65,12 +65,11 @@ class BaseBlock(object):
 
 
 class ColumnOrientedBlock(BaseBlock):
-    tuple_column_types = (list, tuple)
-
     def normalize(self, data):
         if not data:
             return []
 
+        self._check_number_of_columns(data)
         self._check_all_columns_equal_length(data)
         return data
 
@@ -90,6 +89,14 @@ class ColumnOrientedBlock(BaseBlock):
 
     def get_column_by_index(self, index):
         return self.data[index]
+
+    def _check_number_of_columns(self, data):
+        expected_row_len = len(self.columns_with_types)
+
+        got = len(data)
+        if expected_row_len != got:
+            msg = 'Expected {} columns, got {}'.format(expected_row_len, got)
+            raise ValueError(msg)
 
     def _check_all_columns_equal_length(self, data):
         expected = len(data[0])

--- a/clickhouse_driver/block.py
+++ b/clickhouse_driver/block.py
@@ -1,5 +1,3 @@
-from itertools import chain
-
 from .reader import read_varint, read_binary_uint8, read_binary_int32
 from .varint import write_varint
 from .writer import write_binary_uint8, write_binary_int32
@@ -32,47 +30,130 @@ class BlockInfo(object):
                 self.bucket_num = read_binary_int32(buf)
 
 
-class Block(object):
+class BaseBlock(object):
+    def __init__(self, columns_with_types=None, data=None,
+                 info=None, types_check=False):
+        self.columns_with_types = columns_with_types or []
+        self.types_check = types_check
+        self.info = info or BlockInfo()
+        self.data = self.normalize(data or [])
+
+        super(BaseBlock, self).__init__()
+
+    def normalize(self, data):
+        return data
+
+    @property
+    def num_columns(self):
+        raise NotImplementedError
+
+    @property
+    def num_rows(self):
+        raise NotImplementedError
+
+    def get_columns(self):
+        raise NotImplementedError
+
+    def get_rows(self):
+        raise NotImplementedError
+
+    def get_column_by_index(self, index):
+        raise NotImplementedError
+
+    def transposed(self):
+        return list(map(tuple, zip(*self.data)))
+
+
+class ColumnOrientedBlock(BaseBlock):
+    tuple_column_types = (list, tuple)
+
+    def normalize(self, data):
+        if not data:
+            return []
+
+        self._check_all_columns_equal_length(data)
+        return data
+
+    @property
+    def num_columns(self):
+        return len(self.data)
+
+    @property
+    def num_rows(self):
+        return len(self.data[0]) if self.num_columns else 0
+
+    def get_columns(self):
+        return self.data
+
+    def get_rows(self):
+        return self.transposed()
+
+    def get_column_by_index(self, index):
+        return self.data[index]
+
+    def _check_all_columns_equal_length(self, data):
+        expected = len(data[0])
+
+        for column in data:
+            got = len(column)
+            if got != expected:
+                msg = 'Expected {} rows, got {}'.format(expected, got)
+                raise ValueError(msg)
+
+
+class RowOrientedBlock(BaseBlock):
     dict_row_types = (dict, )
     tuple_row_types = (list, tuple)
     supported_row_types = dict_row_types + tuple_row_types
 
-    def __init__(self, columns_with_types=None, data=None, info=None,
-                 types_check=False, received_from_server=False):
-        self.columns_with_types = columns_with_types or []
-        self.data = data or []
-        self.types_check = types_check
+    def normalize(self, data):
+        if not data:
+            return []
 
-        if data and not received_from_server:
-            # Guessing about whole data format by first row.
-            first_row = data[0]
+        # Guessing about whole data format by first row.
+        first_row = data[0]
 
-            if self.types_check:
-                self.check_row_type(first_row)
+        if self.types_check:
+            self._check_row_type(first_row)
 
-            if isinstance(first_row, dict):
-                self.dicts_to_rows(data)
-            else:
-                self.check_rows(data)
+        if isinstance(first_row, dict):
+            self._mutate_dicts_to_rows(data)
+        else:
+            self._check_rows(data)
 
-        self.info = info or BlockInfo()
+        return data
 
-        super(Block, self).__init__()
+    @property
+    def num_columns(self):
+        return len(self.data[0]) if self.num_rows else 0
 
-    def dicts_to_rows(self, data):
+    @property
+    def num_rows(self):
+        return len(self.data)
+
+    def get_columns(self):
+        return self.transposed()
+
+    def get_rows(self):
+        return self.data
+
+    def get_column_by_index(self, index):
+        return [row[index] for row in self.data]
+
+    def _mutate_dicts_to_rows(self, data):
         column_names = [x[0] for x in self.columns_with_types]
 
         check_row_type = False
         if self.types_check:
-            check_row_type = self.check_dict_row_type
+            check_row_type = self._check_dict_row_type
 
         for i, row in enumerate(data):
             if check_row_type:
                 check_row_type(row)
 
-            self.data[i] = [row[name] for name in column_names]
+            data[i] = [row[name] for name in column_names]
 
-    def check_rows(self, data):
+    def _check_rows(self, data):
         expected_row_len = len(self.columns_with_types)
 
         got = len(data[0])
@@ -81,51 +162,27 @@ class Block(object):
             raise ValueError(msg)
 
         if self.types_check:
-            check_row_type = self.check_tuple_row_type
+            check_row_type = self._check_tuple_row_type
             for row in data:
                 check_row_type(row)
 
-    def get_columns(self):
-        return self.data
-
-    def get_rows(self):
-        if not self.data:
-            return self.data
-
-        # Transpose results: columns -> rows.
-        n_rows = self.rows
-
-        flat_data = tuple(chain.from_iterable(self.data))
-
-        # Make rows from slices.
-        # Pick every `n_rows` element from chained columns.
-        return [flat_data[i::n_rows] for i in range(n_rows)]
-
-    def check_row_type(self, row):
+    def _check_row_type(self, row):
         if not isinstance(row, self.supported_row_types):
             raise TypeError(
                 'Unsupported row type: {}. dict, list or tuple is expected.'
                 .format(type(row))
             )
 
-    def check_tuple_row_type(self, row):
+    def _check_tuple_row_type(self, row):
         if not isinstance(row, self.tuple_row_types):
             raise TypeError(
                 'Unsupported row type: {}. list or tuple is expected.'
                 .format(type(row))
             )
 
-    def check_dict_row_type(self, row):
+    def _check_dict_row_type(self, row):
         if not isinstance(row, self.dict_row_types):
             raise TypeError(
                 'Unsupported row type: {}. dict is expected.'
                 .format(type(row))
             )
-
-    @property
-    def columns(self):
-        return len(self.data)
-
-    @property
-    def rows(self):
-        return len(self.data[0]) if self.columns else 0

--- a/clickhouse_driver/client.py
+++ b/clickhouse_driver/client.py
@@ -179,8 +179,7 @@ class Client(object):
                             Causes additional overhead. Defaults to ``False``.
         :param columnar: if specified the result of the SELECT query will be
                          returned in column-oriented form.
-                         It also allows to INSERT columnar data (`list` of
-                         `tuples` with column values)
+                         It also allows to INSERT data in columnar form.
                          Defaults to ``False`` (row-like form).
 
         :return: * Number of inserted rows for INSERT queries with data.

--- a/clickhouse_driver/connection.py
+++ b/clickhouse_driver/connection.py
@@ -6,7 +6,7 @@ from time import time
 
 from . import defines
 from . import errors
-from .block import Block
+from .block import RowOrientedBlock
 from .blockstreamprofileinfo import BlockStreamProfileInfo
 from .bufferedreader import BufferedSocketReader
 from .bufferedwriter import BufferedSocketWriter
@@ -515,12 +515,12 @@ class Connection(object):
 
     def send_external_tables(self, tables, types_check=False):
         for table in tables or []:
-            block = Block(table['structure'], table['data'],
-                          types_check=types_check)
+            block = RowOrientedBlock(table['structure'], table['data'],
+                                     types_check=types_check)
             self.send_data(block, table_name=table['name'])
 
         # Empty block, end of data transfer.
-        self.send_data(Block())
+        self.send_data(RowOrientedBlock())
 
     @contextmanager
     def timeout_setter(self, new_timeout):

--- a/clickhouse_driver/result.py
+++ b/clickhouse_driver/result.py
@@ -25,7 +25,7 @@ class QueryResult(object):
             return
 
         # Header block contains no rows. Pick columns from it.
-        if block.rows:
+        if block.num_rows:
             if self.columnar:
                 columns = block.get_columns()
                 if self.data:

--- a/clickhouse_driver/streams/native.py
+++ b/clickhouse_driver/streams/native.py
@@ -1,4 +1,4 @@
-from ..block import Block, BlockInfo
+from ..block import ColumnOrientedBlock, BlockInfo
 from ..columns.service import read_column, write_column
 from ..reader import read_binary_str
 from ..varint import write_varint, read_varint
@@ -19,8 +19,8 @@ class BlockOutputStream(object):
             block.info.write(self.fout)
 
         # We write transposed data.
-        n_columns = block.rows
-        n_rows = block.columns
+        n_columns = block.num_columns
+        n_rows = block.num_rows
 
         write_varint(n_columns, self.fout)
         write_varint(n_rows, self.fout)
@@ -31,7 +31,7 @@ class BlockOutputStream(object):
 
             if n_columns:
                 try:
-                    items = [row[i] for row in block.data]
+                    items = block.get_column_by_index(i)
                 except IndexError:
                     raise ValueError('Different rows length')
 
@@ -75,11 +75,10 @@ class BlockInputStream(object):
                                      self.fin)
                 data.append(column)
 
-        block = Block(
+        block = ColumnOrientedBlock(
             columns_with_types=list(zip(names, types)),
             data=data,
             info=info,
-            received_from_server=True
         )
 
         return block

--- a/clickhouse_driver/util/helpers.py
+++ b/clickhouse_driver/util/helpers.py
@@ -7,3 +7,22 @@ def chunks(seq, n):
     while item:
         yield item
         item = list(islice(it, n))
+
+
+def column_chunks(columns, n):
+    for column in columns:
+        if not isinstance(column, (list, tuple)):
+            raise TypeError(
+                'Unsupported column type: {}. list or tuple is expected.'
+                .format(type(columns))
+            )
+
+    # create chunk generator for every column
+    g = [chunks(column, n) for column in columns]
+
+    while True:
+        # get next chunk for every column
+        item = [next(column, []) for column in g]
+        if not any(item):
+            break
+        yield item

--- a/clickhouse_driver/util/helpers.py
+++ b/clickhouse_driver/util/helpers.py
@@ -14,7 +14,7 @@ def column_chunks(columns, n):
         if not isinstance(column, (list, tuple)):
             raise TypeError(
                 'Unsupported column type: {}. list or tuple is expected.'
-                .format(type(columns))
+                .format(type(column))
             )
 
     # create chunk generator for every column

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
     ],
     ext_modules=extensions,
     extras_require={
-        'lz4': ['lz4', 'clickhouse-cityhash>=1.0.2.1'],
+        'lz4': ['lz4<=3.0.1', 'clickhouse-cityhash>=1.0.2.1'],
         'zstd': ['zstd', 'clickhouse-cityhash>=1.0.2.1']
     },
     test_suite='nose.collector',
@@ -129,7 +129,7 @@ setup(
         'nose',
         'mock',
         'freezegun',
-        'lz4',
+        'lz4<=3.0.1',
         'zstd',
         'clickhouse-cityhash>=1.0.2.1'
     ],

--- a/tests/columns/test_common.py
+++ b/tests/columns/test_common.py
@@ -22,3 +22,24 @@ class CommonTestCase(BaseTestCase):
             self.assertEqual(inserted, data)
 
         client.disconnect()
+
+    def test_columnar_insert_block_size(self):
+        client = Client(
+            self.host, self.port, self.database, self.user, self.password,
+            settings={'insert_block_size': 1}
+        )
+
+        with self.create_table('a UInt8'):
+            data = [(0, 1, 2, 3)]
+            client.execute(
+                'INSERT INTO test (a) VALUES', data, columnar=True
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(inserted, '0\n1\n2\n3\n')
+            inserted = client.execute(query)
+            expected = [(0, ), (1, ), (2, ), (3, )]
+            self.assertEqual(inserted, expected)
+
+        client.disconnect()

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -147,3 +147,57 @@ class InsertTestCase(BaseTestCase):
                 'INSERT INTO test (a) VALUES', [(x,) for x in range(5)]
             )
             self.assertEqual(rv, 5)
+
+
+class InsertColumnarTestCase(BaseTestCase):
+    def test_insert_tuple_ok(self):
+        with self.create_table('a Int8, b Int8'):
+            data = [(1, 2, 3), (4, 5, 6)]
+            self.client.execute(
+                'INSERT INTO test (a, b) VALUES', data, columnar=True
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(inserted, '1\t4\n2\t5\n3\t6\n')
+            inserted = self.client.execute(query)
+            self.assertEqual(inserted, [(1, 4), (2, 5), (3, 6)])
+            inserted = self.client.execute(query, columnar=True)
+            self.assertEqual(inserted, [(1, 2, 3), (4, 5, 6)])
+
+    def test_insert_data_different_column_length(self):
+        with self.create_table('a Int8, b Int8'):
+            with self.assertRaises(ValueError) as e:
+                data = [(1, 2, 3), (4, 5)]
+                self.client.execute(
+                    'INSERT INTO test (a, b) VALUES', data, columnar=True
+                )
+            self.assertEqual(str(e.exception), 'Expected 3 rows, got 2')
+
+    def test_data_invalid_types(self):
+        with self.create_table('a Int8'):
+            with self.assertRaises(TypeError) as e:
+                data = [{'a': 1}, (2, )]
+                self.client.execute(
+                    'INSERT INTO test (a) VALUES', data,
+                    types_check=True, columnar=True
+                )
+
+            self.assertIn('list or tuple is expected', str(e.exception))
+
+            with self.assertRaises(TypeError) as e:
+                data = [(1, ), {'a': 2}]
+                self.client.execute(
+                    'INSERT INTO test (a) VALUES', data,
+                    types_check=True, columnar=True
+                )
+
+            self.assertIn('list or tuple is expected', str(e.exception))
+
+    def test_data_malformed_columns(self):
+        with self.create_table('a Int8'):
+            with self.assertRaises(TypeError):
+                data = [1]
+                self.client.execute(
+                    'INSERT INTO test (a) VALUES', data, columnar=True
+                )


### PR DESCRIPTION
There is some overhead when you trying to insert columnar data (e.g. read from parquet files) into Clickhouse via clickhouse-driver because you need to transpose data for `execute` method. Transposing data is both memory and time consuming, furthermore, the native protocol was designed to send data by columns.
My simple [benchmark](https://gist.github.com/Anexen/ceaabc2346c575859ea0d71ffc2b53ef) shows ~20% decrease in both insertion time and memory consumption while inserting columnar data.