### PR TITLE
Handle alternate forms of `Decimal(P,S)`: `Decimal64(S)` etc. in `create_decimal_column`

### DIFF
--- a/clickhouse_driver/columns/decimalcolumn.py
+++ b/clickhouse_driver/columns/decimalcolumn.py
@@ -1,5 +1,6 @@
 from decimal import Decimal, localcontext
 
+from .. import errors
 from ..writer import MAX_UINT64, MAX_INT64
 from ..util import compat
 from .base import FormatColumn
@@ -171,7 +172,7 @@ def create_decimal_column(spec, column_options):
             precision = 38 - scale
             cls = Decimal128Column
         else:
-            assert False, (
+            raise errors.UnknownTypeError(
                 "Expected spec to be one of "
                 "{{ 'Decimal(P,S)', 'Decimal32(S)', 'Decimal64('S')', 'Decimal128(S)' }}, got '{}' instead."
                 .format(spec)

--- a/tests/test_decimalcolumn.py
+++ b/tests/test_decimalcolumn.py
@@ -1,13 +1,14 @@
 from clickhouse_driver.columns.decimalcolumn import \
     create_decimal_column, Decimal32Column, Decimal64Column, Decimal128Column
 from tests.testcase import BaseTestCase
+from clickhouse_driver import errors
 
 class DecimalColumnTestCase(BaseTestCase):
-    def test_create_column_DecimalPS(self):
+    def test_create_column_decimal_p_s(self):
         col = create_decimal_column(spec='Decimal(18,4)', column_options={})
         self.assertIsInstance(col, Decimal64Column)
 
-    def test_create_column_Decimal_bits_S(self):
+    def test_create_column_decimal_bits_s(self):
         col32 = create_decimal_column(spec='Decimal32(4)', column_options={})
         col64 = create_decimal_column(spec='Decimal64(4)', column_options={})
         col128 = create_decimal_column(spec='Decimal128(4)', column_options={})
@@ -15,6 +16,6 @@ class DecimalColumnTestCase(BaseTestCase):
         self.assertIsInstance(col64, Decimal64Column)
         self.assertIsInstance(col128, Decimal128Column)
 
-    def test_create_column_Decimal_bad(self):
-        with self.assertRaises(AssertionError):
+    def test_create_column_decimal_unknown_type(self):
+        with self.assertRaises(errors.UnknownTypeError):
             create_decimal_column(spec='Decimal50(4)', column_options={})

--- a/tests/test_decimalcolumn.py
+++ b/tests/test_decimalcolumn.py
@@ -1,0 +1,20 @@
+from clickhouse_driver.columns.decimalcolumn import \
+    create_decimal_column, Decimal32Column, Decimal64Column, Decimal128Column
+from tests.testcase import BaseTestCase
+
+class DecimalColumnTestCase(BaseTestCase):
+    def test_create_column_DecimalPS(self):
+        col = create_decimal_column(spec='Decimal(18,4)', column_options={})
+        self.assertIsInstance(col, Decimal64Column)
+
+    def test_create_column_Decimal_bits_S(self):
+        col32 = create_decimal_column(spec='Decimal32(4)', column_options={})
+        col64 = create_decimal_column(spec='Decimal64(4)', column_options={})
+        col128 = create_decimal_column(spec='Decimal128(4)', column_options={})
+        self.assertIsInstance(col32, Decimal32Column)
+        self.assertIsInstance(col64, Decimal64Column)
+        self.assertIsInstance(col128, Decimal128Column)
+
+    def test_create_column_Decimal_bad(self):
+        with self.assertRaises(AssertionError):
+            create_decimal_column(spec='Decimal50(4)', column_options={})


### PR DESCRIPTION
Fixes #129. I'm not at all deeply familiar with ClickHouse, so this might not be adequate.