### PR TITLE
[RFC] Do not require settings declaration if server support setting-as-string

### DIFF
--- a/clickhouse_driver/settings/types.py
+++ b/clickhouse_driver/settings/types.py
@@ -1,58 +1,46 @@
 from ..util.compat import asbool
 from ..varint import write_varint
-from ..writer import write_binary_str, write_binary_uint8
+from ..writer import write_binary_str
 
 
 class SettingType(object):
     @classmethod
-    def write_is_important(cls, buf, as_string):
-        if as_string:
-            write_binary_uint8(0, buf)
+    def write(cls, value, buf):
+        cls.write_value(value, buf)
 
     @classmethod
-    def write(cls, value, buf, as_string):
-        cls.write_is_important(buf, as_string)
-        cls.write_value(value, buf, as_string)
-
-    @classmethod
-    def write_value(cls, value, buf, as_string):
+    def write_value(cls, value, buf):
         raise NotImplementedError
 
 
 class SettingUInt64(SettingType):
     @classmethod
-    def write_value(cls, value, buf, as_string):
-        if as_string:
-            write_binary_str(str(value), buf)
-        else:
-            write_varint(int(value), buf)
+    def write_value(cls, value, buf):
+        write_varint(int(value), buf)
 
 
 class SettingBool(SettingType):
     @classmethod
-    def write_value(cls, value, buf, as_string):
+    def write_value(cls, value, buf):
         value = asbool(value)
-        if as_string:
-            write_binary_str(str(int(value)), buf)
-        else:
-            write_varint(value, buf)
+        write_varint(value, buf)
 
 
 class SettingString(SettingType):
     @classmethod
-    def write_value(cls, value, buf, as_string):
+    def write_value(cls, value, buf):
         write_binary_str(value, buf)
 
 
 class SettingChar(SettingType):
     @classmethod
-    def write_value(cls, value, buf, as_string):
+    def write_value(cls, value, buf):
         write_binary_str(value[0], buf)
 
 
 class SettingFloat(SettingType):
     @classmethod
-    def write_value(cls, value, buf, as_string):
+    def write_value(cls, value, buf):
         """
         Float is written in string representation.
         """
@@ -61,10 +49,7 @@ class SettingFloat(SettingType):
 
 class SettingMaxThreads(SettingUInt64):
     @classmethod
-    def write_value(cls, value, buf, as_string):
-        if as_string:
-            write_binary_str(str(value), buf)
-        else:
-            if value == 'auto':
-                value = 0
-            super(SettingMaxThreads, cls).write_value(value, buf, as_string)
+    def write_value(cls, value, buf):
+        if value == 'auto':
+            value = 0
+        super(SettingMaxThreads, cls).write_value(value, buf)

--- a/clickhouse_driver/settings/writer.py
+++ b/clickhouse_driver/settings/writer.py
@@ -1,6 +1,6 @@
 import logging
 
-from ..writer import write_binary_str
+from ..writer import write_binary_str, write_binary_uint8
 from .available import settings as available_settings
 
 
@@ -9,13 +9,21 @@ logger = logging.getLogger(__name__)
 
 def write_settings(settings, buf, settings_as_strings):
     for setting, value in (settings or {}).items():
-        setting_writer = available_settings.get(setting)
-
-        if not setting_writer:
-            logger.warning('Unknown setting %s. Skipping', setting)
+        # If the server support settings as string we do not need to know
+        # anything about them, so we can write any setting.
+        if settings_as_strings:
+            write_binary_str(setting, buf)
+            write_binary_uint8(0, buf)
+            write_binary_str(str(value), buf)
             continue
 
+        # If the server requires string in binary, then they cannot be written
+        # without type.
+        setting_writer = available_settings.get(setting)
+        if not setting_writer:
+            logger.warning('Unknown setting %s. Type is unknown. Skipping', setting)
+            continue
         write_binary_str(setting, buf)
-        setting_writer.write(value, buf, settings_as_strings)
+        setting_writer.write(value, buf)
 
     write_binary_str('', buf)  # end of settings


### PR DESCRIPTION
New settings are added frequently, more then clickhouse-driver has new
release.

The downside is that bool type detection now depends from the server,
and it does not recognize 'yes'/'2', but recognize 'true'/'1', but I
guess it is ok.
(plus I'm not sure that it was a good idea to ignore case for char
settings, if the string has more then 1 char)

History of syncing settings with upstream:
- #141 
- #133 
- #123 
- #111 