### PR TITLE
Fix issue when row contains an empty nested array

### DIFF
--- a/clickhouse_driver/columns/arraycolumn.py
+++ b/clickhouse_driver/columns/arraycolumn.py
@@ -172,10 +172,11 @@ class ArrayColumn(Column):
             else:
                 prev_offset += size
 
-        data = nested_column._read_data(
-            nested_column_size, buf,
-            nulls_map=nulls_map
-        )
+        data = []
+        if nested_column_size:
+            data = nested_column._read_data(
+                nested_column_size, buf, nulls_map=nulls_map
+            )
 
         # Build nested tuple structure.
         for slices, nulls_map in reversed(slices_series):

--- a/tests/columns/test_array.py
+++ b/tests/columns/test_array.py
@@ -105,6 +105,24 @@ class ArrayTestCase(BaseTestCase):
             inserted = self.client.execute(query)
             self.assertEqual(inserted, data)
 
+    def test_empty_nested(self):
+        columns = "a Array(Array(Array(Int32))), b Array(Array(Array(Int32)))"
+        data = [
+            ([], [[]],),
+        ]
+
+        with self.create_table(columns):
+            self.client.execute("INSERT INTO test (a, b) VALUES", data)
+
+            query = "SELECT * FROM test"
+            inserted = self.emit_cli(query)
+            self.assertEqual(
+                inserted, "[]\t[[]]\n",
+            )
+
+            inserted = self.client.execute(query)
+            self.assertEqual(inserted, data)
+
     def test_type_mismatch_error(self):
         columns = 'a Array(Int32)'
         data = [('test', )]


### PR DESCRIPTION
Hi, I'd appreciate a review on this as I'm not certain correct approach was used to solve it.

This PR fixes an issue where clickhouse driver is raising a `NotImplemented` error when all rows in result set are empty nested arrays causing the following exception:

```/usr/local/lib/python3.7/site-packages/clickhouse_driver/columns/arraycolumn.py in _read(self, size, buf)
    175         data = nested_column._read_data(
    176             nested_column_size, buf,
--> 177             nulls_map=nulls_map
    178         )
    179

/usr/local/lib/python3.7/site-packages/clickhouse_driver/columns/base.py in _read_data(self, n_items, buf, nulls_map)
     93
     94     def _read_data(self, n_items, buf, nulls_map=None):
---> 95         items = self.read_items(n_items, buf)
     96
     97         if self.after_read_items:

/usr/local/lib/python3.7/site-packages/clickhouse_driver/columns/base.py in read_items(self, n_items, buf)
    105
    106     def read_items(self, n_items, buf):
--> 107         raise NotImplementedError
    108
    109     def read_state_prefix(self, buf):

NotImplementedError:
```

After the fix the queries work and match output from clickhouse:

### Clickhouse client
```
Debian-99-stretch-64-minimal :) CREATE TABLE test (id Int32, a Array(Array(Array(Int32)))) ENGINE MergeTree ORDER BY id;

CREATE TABLE test
(
    `id` Int32,
    `a` Array(Array(Array(Int32)))
)
ENGINE = MergeTree
ORDER BY id

Ok.

0 rows in set. Elapsed: 0.016 sec.

Debian-99-stretch-64-minimal :) INSERT INTO test VALUES
:-]     (1, []),
:-]     (2, [[]]),
:-]     (3, [[[]]]),
:-]     (4, [[[],[]]]),
:-]     (5, [[[],[]],[]]),
:-]     (6, [[[],[]],[[]]]),
:-]     (7, [[[],[]],[[],[]]]),
:-]     (8, [[[1],[2]],[[],[]]])
:-]     (9, [[[1,2],[2,3]],[[],[]]])
:-] ,;

INSERT INTO test VALUES

Ok.

9 rows in set. Elapsed: 0.005 sec.

Debian-99-stretch-64-minimal :) SELECT * FROM test;

SELECT *
FROM test

┌─id─┬─a───────────────────────┐
│  1 │ []                      │
│  2 │ [[]]                    │
│  3 │ [[[]]]                  │
│  4 │ [[[],[]]]               │
│  5 │ [[[],[]],[]]            │
│  6 │ [[[],[]],[[]]]          │
│  7 │ [[[],[]],[[],[]]]       │
│  8 │ [[[1],[2]],[[],[]]]     │
│  9 │ [[[1,2],[2,3]],[[],[]]] │
└────┴─────────────────────────┘

9 rows in set. Elapsed: 0.005 sec.
Debian-99-stretch-64-minimal :) SELECT * FROM test limit 2;

SELECT *
FROM test
LIMIT 2

┌─id─┬─a────┐
│  1 │ []   │
│  2 │ [[]] │
└────┴──────┘

2 rows in set. Elapsed: 0.004 sec.
```

### Python client
```python
In [3]: clickhouse_driver.Client(...).execute('select * from test')
Out[3]: 
[(1, []),
 (2, [[]]),
 (3, [[[]]]),
 (4, [[[], []]]),
 (5, [[[], []], []]),
 (6, [[[], []], [[]]]),
 (7, [[[], []], [[], []]]),
 (8, [[[1], [2]], [[], []]]),
 (9, [[[1, 2], [2, 3]], [[], []]])]

In [4]: clickhouse_driver.Client(...).execute('select * from test limit 2') # this query fails before
Out[4]: [(1, []), (2, [[]])]``` 