### PR TITLE
Fix Enum type parsing when it wrapped in SimpleAggregateFunction

### DIFF
--- a/clickhouse_driver/columns/simpleaggregatefunctioncolumn.py
+++ b/clickhouse_driver/columns/simpleaggregatefunctioncolumn.py
@@ -2,6 +2,6 @@
 
 def create_simple_aggregate_function_column(spec, column_by_spec_getter):
     # SimpleAggregateFunction(Func, Type) -> Type
-    inner = spec[24:-1].split(',')[1].strip()
+    inner = spec[24:-1].split(',', maxsplit=1)[1].strip()
     nested = column_by_spec_getter(inner)
     return nested

--- a/tests/columns/test_enum.py
+++ b/tests/columns/test_enum.py
@@ -149,3 +149,64 @@ class EnumTestCase(BaseTestCase):
                     (None, ), ('hello', ), (None, ), ('world', ),
                 ]
             )
+
+    def test_simple_agg_function(self):
+        columns = "a SimpleAggregateFunction(anyLast, " \
+                  "Enum8('hello' = -1, 'world' = 2))"
+
+        data = [(A.hello,), (A.world,), (-1,), (2,)]
+        with self.create_table(columns):
+            self.client.execute(
+                'INSERT INTO test (a) VALUES', data
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(
+                inserted, (
+                    'hello\n'
+                    'world\n'
+                    'hello\n'
+                    'world\n'
+                )
+            )
+
+            inserted = self.client.execute(query)
+            self.assertEqual(
+                inserted, [
+                    ('hello',), ('world',),
+                    ('hello',), ('world',)
+                ]
+            )
+
+    def test_simple_agg_function_nullable(self):
+        columns = "a SimpleAggregateFunction(anyLast, " \
+                  "Nullable(Enum8('hello' = -1, 'world' = 2)))"
+
+        data = [(A.hello,), (A.world,), (None,), (-1,), (2,)]
+        with self.create_table(columns):
+            self.client.execute(
+                'INSERT INTO test (a) VALUES', data
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(
+                inserted, (
+                    'hello\n'
+                    'world\n'
+                    '\\N\n'
+                    'hello\n'
+                    'world\n'
+                )
+            )
+
+            inserted = self.client.execute(query)
+            self.assertEqual(
+                inserted, [
+                    ('hello',), ('world',),
+                    (None, ),
+                    ('hello',), ('world',)
+                ]
+            )
+


### PR DESCRIPTION
If `SimpleAggregateFunction(Enum('a'=1,'b'=2))` queried by driver (with any Enum parameters), it can't be correcty parsed by function `create_simple_aggregate_function_column`, because it splits by comma to get secondary type of a SimpleAggregateFunction, but Enum type contains coma too.

Covered by tests.