### PR TITLE
Add ability to mark settings as important to fail on unknown settings

### DIFF
--- a/clickhouse_driver/client.py
+++ b/clickhouse_driver/client.py
@@ -567,6 +567,9 @@ class Client(object):
             elif name == 'compress_block_size':
                 kwargs[name] = int(value)
 
+            elif name == 'settings_is_important':
+                kwargs[name] = asbool(value)
+
             # ssl
             elif name == 'verify':
                 kwargs[name] = asbool(value)

--- a/clickhouse_driver/connection.py
+++ b/clickhouse_driver/connection.py
@@ -110,6 +110,9 @@ class Connection(object):
     :param ciphers: see :func:`ssl.wrap_socket` docs.
     :param alt_hosts: list of alternative hosts for connection.
                       Example: alt_hosts=host1:port1,host2:port2.
+    :param settings_is_important: 0 means unknown settings will be ignored,
+                                  1 means that the query will fail with
+                                  UNKNOWN_SETTING error.
     """
 
     def __init__(
@@ -124,7 +127,8 @@ class Connection(object):
             secure=False,
             # Secure socket parameters.
             verify=True, ssl_version=None, ca_certs=None, ciphers=None,
-            alt_hosts=None
+            alt_hosts=None,
+            settings_is_important=0,
     ):
         if secure:
             default_port = defines.DEFAULT_SECURE_PORT
@@ -145,6 +149,7 @@ class Connection(object):
         self.connect_timeout = connect_timeout
         self.send_receive_timeout = send_receive_timeout
         self.sync_request_timeout = sync_request_timeout
+        self.settings_is_important = settings_is_important
 
         self.secure_socket = secure
         self.verify_cert = verify
@@ -563,7 +568,7 @@ class Connection(object):
             revision >= defines
             .DBMS_MIN_REVISION_WITH_SETTINGS_SERIALIZED_AS_STRINGS
         )
-        write_settings(self.context.settings, self.fout, settings_as_strings)
+        write_settings(self.context.settings, self.fout, settings_as_strings, self.settings_is_important)
 
         if revision >= defines.DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET:
             write_binary_str('', self.fout)

--- a/clickhouse_driver/settings/writer.py
+++ b/clickhouse_driver/settings/writer.py
@@ -7,9 +7,7 @@ from .available import settings as available_settings
 logger = logging.getLogger(__name__)
 
 
-def write_settings(settings, buf, settings_as_strings):
-    is_important = 0
-
+def write_settings(settings, buf, settings_as_strings, is_important=0):
     for setting, value in (settings or {}).items():
         # If the server support settings as string we do not need to know
         # anything about them, so we can write any setting.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -174,6 +174,17 @@ class ClientFromUrlTestCase(TestCase):
             c.connection.context.client_settings['insert_block_size'], 123
         )
 
+    def test_settings_is_important(self):
+        c = Client.from_url('clickhouse://host?settings_is_important=1')
+        self.assertEqual(c.connection.settings_is_important, True)
+
+        with self.assertRaises(ValueError):
+            c = Client.from_url('clickhouse://host?settings_is_important=2')
+            self.assertEqual(c.connection.settings_is_important, True)
+
+        c = Client.from_url('clickhouse://host?settings_is_important=0')
+        self.assertEqual(c.connection.settings_is_important, False)
+
     @check_numpy
     def test_use_numpy(self):
         c = Client.from_url('clickhouse://host?use_numpy=true')


### PR DESCRIPTION
Skipping unknown settings is not always the required behaviour, and most
of the time you want the opposite - fail on unknown setting.

Image that you pass some new setting, i.e. max_insert_threads, and you
assume that the INSERT will be parallel, however due to you server was
too old the setting is silently ignored.

*P.S. the initial is_important=0 by default was because previously clickhouse-driver ignores any unknown settings (well message in the log doesn't counts)*

Refs: #142