### PR TITLE
Fix: case when Decimal(N, 1) was incorrect interpreted

### DIFF
--- a/clickhouse_driver/columns/decimalcolumn.py
+++ b/clickhouse_driver/columns/decimalcolumn.py
@@ -25,7 +25,7 @@ class DecimalColumn(FormatColumn):
             self.check_item = check_item
 
     def after_read_items(self, items, nulls_map=None):
-        if self.scale > 1:
+        if self.scale >= 1:
             scale = 10 ** self.scale
 
             if nulls_map is None:
@@ -47,7 +47,7 @@ class DecimalColumn(FormatColumn):
     def before_write_items(self, items, nulls_map=None):
         null_value = self.null_value
 
-        if self.scale > 1:
+        if self.scale >= 1:
             scale = 10 ** self.scale
 
             for i, item in enumerate(items):

--- a/tests/columns/test_decimal.py
+++ b/tests/columns/test_decimal.py
@@ -192,6 +192,22 @@ class DecimalTestCase(BaseTestCase):
                 (Decimal('1.15'), )
             ])
 
+    def test_precision_one_sign_after_point(self):
+        data = [(1.6, ), (1.0, ), (12312.0, ), (999999.6, )]
+
+        with self.create_table('a Decimal(8, 1)'):
+            self.client.execute('INSERT INTO test (a) VALUES', data)
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            print("inserted:", inserted)
+            self.assertEqual(inserted, '1.6\n1.0\n12312.0\n999999.6\n')
+            inserted = self.client.execute(query)
+            self.assertEqual(inserted, [
+                (Decimal('1.6'),),
+                (Decimal('1.0'),),
+                (Decimal('12312.0'),),
+                (Decimal('999999.6'),)
+            ])
 
 class Decimal256TestCase(BaseTestCase):
     required_server_version = (18, 12, 13)


### PR DESCRIPTION
Any values in column with type Decimal(N, 1) was interpreted by clickhouse-driver without point.

Example:
12312.1 => clickhouse-driver => 123121
1660.0 => clickhouse-driver => 16600

That is not correct, I checked query result through HTTP interface and got correct result:
12312.1 => http => 12312.1
1660.0 => http => 1660.0

This PR closes this error.