### PR TITLE
Clickhouse DateTime64 extended range

### DIFF
--- a/clickhouse_driver/columns/datetimecolumn.py
+++ b/clickhouse_driver/columns/datetimecolumn.py
@@ -87,7 +87,7 @@ class DateTimeColumn(FormatColumn):
 
 class DateTime64Column(DateTimeColumn):
     ch_type = 'DateTime64'
-    format = 'Q'
+    format = 'q'
 
     max_scale = 6
 

--- a/tests/columns/test_datetime.py
+++ b/tests/columns/test_datetime.py
@@ -135,6 +135,21 @@ class DateTimeTestCase(BaseDateTimeTestCase):
             inserted = self.emit_cli(query)
             self.assertEqual(inserted, '0\n1\n1500000000\n4294967295\n')
 
+    @require_server_version(21, 4)
+    def test_insert_datetime64_extended_range(self):
+        with self.create_table("a DateTime64(0, 'UTC')"):
+            self.client.execute(
+                'INSERT INTO test (a) VALUES',
+                [(0, ), (1, ), (-2**63, ), (2**63-1, )]
+            )
+
+            query = 'SELECT toInt64(a) FROM test ORDER BY a'
+            inserted = self.emit_cli(query)
+            self.assertEqual(
+                inserted,
+                '-9223372036854775808\n0\n1\n9223372036854775807\n'
+            )
+
 
 class DateTimeTimezonesTestCase(BaseDateTimeTestCase):
     dt_type = 'DateTime'


### PR DESCRIPTION
Clickhouse has extended range of DateTime64 to support dates from year 1925 to 2283.
https://clickhouse.tech/docs/en/whats-new/changelog/#clickhouse-release-21-4
https://github.com/ClickHouse/ClickHouse/pull/9404

SELECT
    toDateTime64(-9223372036854775808, 0, 'UTC') AS start,
    toDateTime64(9223372036854775807, 0, 'UTC') AS end

┌───────────────start─┬─────────────────end─┐
│ 1925-01-01 00:00:00 │ 2282-12-31 00:00:00 │
└─────────────────────┴─────────────────────┘