### PR TITLE
ERROR TO SOLVE

### DIFF
--- a/clickhouse_driver/columns/decimalcolumn.py
+++ b/clickhouse_driver/columns/decimalcolumn.py
@@ -8,15 +8,15 @@ from .intcolumn import Int128Column, Int256Column
 class DecimalColumn(FormatColumn):
     py_types = (Decimal, float, int)
     max_precision = None
-    int_size = None
+    int_size = None # <-
 
     def __init__(self, precision, scale, types_check=False, **kwargs):
         self.precision = precision
         self.scale = scale
         super(DecimalColumn, self).__init__(**kwargs)
 
-        if types_check:
-            max_signed_int = (1 << (8 * self.int_size - 1)) - 1
+        if types_check: # <-
+            max_signed_int = (1 << (8 * self.int_size - 1)) - 1 # <- 
 
             def check_item(value):
                 if value < -max_signed_int or value > max_signed_int:
@@ -86,11 +86,11 @@ class Decimal32Column(DecimalColumn):
 class Decimal64Column(DecimalColumn):
     format = 'q'
     max_precision = 18
-    int_size = 8
+    int_size = 8 ## <-
 
 
 class Decimal128Column(DecimalColumn, Int128Column):
-    max_precision = 38
+    max_precision = 38 ## <-
 
 
 class Decimal256Column(DecimalColumn, Int256Column):


### PR DESCRIPTION
WITH TYPES_CHECK = TRUE (IMPORTANT) after creating and trying to insert into a table with Decimal128(12) columns, an error is catched and execution stops because:
class Decimal128 doesn't assign an int_size, so when max_signed_int is to be calculated, it will multiply 8*None. 

ERROR
File "/usr/local/lib/python3.9/site-packages/clickhouse_driver/columns/decimalcolumn.py", line 19, in __init__
    max_signed_int = (1 << (8 * self.int_size - 1)) - 1
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'


How can we solve this?