### PR TITLE
(Seeking feedback) load array columns as numpy array instead of list if use_numpy=True

### DIFF
--- a/clickhouse_driver/columns/numpy/arraycolumn.py
+++ b/clickhouse_driver/columns/numpy/arraycolumn.py
@@ -1,0 +1,47 @@
+import numpy as np
+from struct import Struct
+
+from ..arraycolumn import ArrayColumn
+from ...util.helpers import pairwise
+
+class NumpyArrayColumn(ArrayColumn):
+    def _read(self, size, buf):
+        slices_series = [[0, size]]
+        nested_column = self.nested_column
+
+        cur_level_slice_size = size
+        cur_level_slice = None
+        while (isinstance(nested_column, ArrayColumn)):
+            if cur_level_slice is None:
+                cur_level_slice = [0]
+            ns = Struct('<{}Q'.format(cur_level_slice_size))
+            nested_sizes = ns.unpack(buf.read(ns.size))
+            cur_level_slice.extend(nested_sizes)
+            slices_series.append(cur_level_slice)
+            cur_level_slice = None
+            cur_level_slice_size = nested_sizes[-1] if len(nested_sizes) > 0 \
+                else 0
+            nested_column = nested_column.nested_column
+
+        n_items = cur_level_slice_size if size > 0 else 0
+        nulls_map = None
+        if nested_column.nullable:
+            nulls_map = self._read_nulls_map(n_items, buf)
+
+        data = []
+        if n_items:
+            # use numpy array instead of list to improve memory usage
+            # (especially for arrays of scalar types)
+            data = np.array(nested_column._read_data(
+                n_items, buf, nulls_map=nulls_map
+            ))
+
+        # Build nested structure.
+        for slices in reversed(slices_series):
+            data = [data[begin:end] for begin, end in pairwise(slices)]
+
+        return tuple(data)
+
+def create_numpy_array_column(spec, column_by_spec_getter):
+    inner = spec[6:-1]
+    return NumpyArrayColumn(column_by_spec_getter(inner))

--- a/clickhouse_driver/columns/numpy/service.py
+++ b/clickhouse_driver/columns/numpy/service.py
@@ -1,5 +1,5 @@
 from ... import errors
-from ..arraycolumn import create_array_column
+from .arraycolumn import create_numpy_array_column
 from .datecolumn import NumpyDateColumn
 from .datetimecolumn import create_numpy_datetime_column
 from ..decimalcolumn import create_decimal_column
@@ -55,7 +55,7 @@ def get_numpy_column_by_spec(spec, column_options):
         return create_decimal_column(spec, column_options)
 
     elif spec.startswith('Array'):
-        return create_array_column(spec, create_column_with_options)
+        return create_numpy_array_column(spec, create_column_with_options)
 
     elif spec.startswith('Tuple'):
         return create_tuple_column(spec, create_column_with_options)


### PR DESCRIPTION
Our clickhouse table has a column with the type `Array(Float32)` where each array has a length of about 10,000. I was interested in using the numpy support in clickhouse-driver to integrate efficiently with dask, but I found that array types are still loaded into a list, which is quite wasteful of memory compared to a numpy array.

After some hacking, these changes seem to work for my use-case, but I realise that there are probably a lot of edge cases with more complex/nested array types that I haven't tested. Using an array instead of a list may also have broken other things and would also possibly be considered a breaking change to the API for users.

Basically, I was wondering if you support something like this and whether you can think of a clean way to implement it properly? I'm happy to attempt implementing it myself given some guidance.