### PR TITLE
create error message before disconnect

### DIFF
--- a/clickhouse_driver/connection.py
+++ b/clickhouse_driver/connection.py
@@ -433,9 +433,9 @@ class Connection(object):
             raise self.receive_exception()
 
         else:
-            self.disconnect()
             message = self.unexpected_packet_message('Hello or Exception',
                                                      packet_type)
+            self.disconnect()
             raise errors.UnexpectedPacketFromServerError(message)
 
     def ping(self):


### PR DESCRIPTION
If we do disconnect before creating error message than we have None in host and port fields in error message like:
`clickhouse_driver.errors.UnexpectedPacketFromServerError: Code: 102. Unexpected packet from server None:None (expected Hello or Exception, got Unknown packet)`