### PR TITLE
Fix issue #179 - insertion using row values

### DIFF
--- a/clickhouse_driver/dbapi/cursor.py
+++ b/clickhouse_driver/dbapi/cursor.py
@@ -310,7 +310,7 @@ class Cursor(object):
             self._rowcount = response
             response = None
 
-        if not response:
+        if not response or isinstance(response, int):
             self._columns = self._types = self._rows = []
             return
 

--- a/tests/test_dbapi.py
+++ b/tests/test_dbapi.py
@@ -151,6 +151,13 @@ class DBAPITestCase(DBAPITestCaseBase):
             )
             self.assertEqual(cursor.rowcount, -1)
 
+    def test_execute_insert(self):
+        with self.created_cursor() as cursor, self.create_table('a UInt8'):
+            cursor.execute(
+                'INSERT INTO test VALUES',
+                parameters=[[1]]
+            )
+
     def test_description(self):
         with self.created_cursor() as cursor:
             self.assertIsNone(cursor.description)


### PR DESCRIPTION
The issue has been fixed, it allows to use `.execute` for all kinds of command