### PR TITLE
Fix: Variables cannot be declared with 'cpdef'

### DIFF
--- a/clickhouse_driver/columns/largeint.pyx
+++ b/clickhouse_driver/columns/largeint.pyx
@@ -3,8 +3,8 @@ from cpython.tuple cimport PyTuple_New, PyTuple_SET_ITEM
 
 from .. import writer
 
-cpdef object MAX_UINT64 = writer.MAX_UINT64
-cpdef object MAX_INT64 = writer.MAX_INT64
+cdef object MAX_UINT64 = writer.MAX_UINT64
+cdef object MAX_INT64 = writer.MAX_INT64
 
 
 def int128_from_quads(quad_items, unsigned long long n_items):


### PR DESCRIPTION
Currently, clickhouse-driver is broken after Cython 3.0.0a8 due to [dropped support of cpdef](https://cython.readthedocs.io/en/latest/src/changes.html#id8):

```
Variables can no longer be declared with cpdef. Patch by David Woods. (Github issue #887)
```


```
[pipenv.exceptions.InstallError]: Collecting clickhouse-driver[lz4]==0.2.2
[pipenv.exceptions.InstallError]:   Using cached clickhouse-driver-0.2.2.tar.gz (212 kB)
[pipenv.exceptions.InstallError]:   Preparing metadata (setup.py): started
[pipenv.exceptions.InstallError]:   Preparing metadata (setup.py): finished with status 'error'
[pipenv.exceptions.InstallError]: ERROR: Command errored out with exit status 1:
[pipenv.exceptions.InstallError]:    command: /Users/aveline/.local/share/virtualenvs/misaka-D00KXp59/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/8g/y5c2zpzd1rl3kyt__7kxk1p00000gn/T/pip-install-so9ryf2q/clickhouse-driver_5f155666511d4548aed9ad996a6662cb/setup.py'"'"'; __file__='"'"'/private/var/folders/8g/y5c2zpzd1rl3kyt__7kxk1p00000gn/T/pip-install-so9ryf2q/clickhouse-driver_5f155666511d4548aed9ad996a6662cb/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/8g/y5c2zpzd1rl3kyt__7kxk1p00000gn/T/pip-pip-egg-info-rtilg7q3
[pipenv.exceptions.InstallError]:        cwd: /private/var/folders/8g/y5c2zpzd1rl3kyt__7kxk1p00000gn/T/pip-install-so9ryf2q/clickhouse-driver_5f155666511d4548aed9ad996a6662cb/
[pipenv.exceptions.InstallError]:   Complete output (44 lines):
[pipenv.exceptions.InstallError]:   
[pipenv.exceptions.InstallError]:   Error compiling Cython file:
[pipenv.exceptions.InstallError]:   ------------------------------------------------------------
[pipenv.exceptions.InstallError]:   ...
[pipenv.exceptions.InstallError]:   from cpython cimport Py_INCREF
[pipenv.exceptions.InstallError]:   from cpython.tuple cimport PyTuple_New, PyTuple_SET_ITEM
[pipenv.exceptions.InstallError]:   
[pipenv.exceptions.InstallError]:   from .. import writer
[pipenv.exceptions.InstallError]:   
[pipenv.exceptions.InstallError]:   cpdef object MAX_UINT64 = writer.MAX_UINT64
[pipenv.exceptions.InstallError]:        ^
[pipenv.exceptions.InstallError]:   ------------------------------------------------------------
[pipenv.exceptions.InstallError]:   
[pipenv.exceptions.InstallError]:   clickhouse_driver/columns/largeint.pyx:6:6: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
[pipenv.exceptions.InstallError]:   
[pipenv.exceptions.InstallError]:   Error compiling Cython file:
[pipenv.exceptions.InstallError]:   ------------------------------------------------------------
[pipenv.exceptions.InstallError]:   ...
[pipenv.exceptions.InstallError]:   from cpython.tuple cimport PyTuple_New, PyTuple_SET_ITEM
[pipenv.exceptions.InstallError]:   
[pipenv.exceptions.InstallError]:   from .. import writer
[pipenv.exceptions.InstallError]:   
[pipenv.exceptions.InstallError]:   cpdef object MAX_UINT64 = writer.MAX_UINT64
[pipenv.exceptions.InstallError]:   cpdef object MAX_INT64 = writer.MAX_INT64
[pipenv.exceptions.InstallError]:        ^
[pipenv.exceptions.InstallError]:   ------------------------------------------------------------
[pipenv.exceptions.InstallError]:   
[pipenv.exceptions.InstallError]:   clickhouse_driver/columns/largeint.pyx:7:6: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
[pipenv.exceptions.InstallError]:   Traceback (most recent call last):
[pipenv.exceptions.InstallError]:     File "<string>", line 1, in <module>
[pipenv.exceptions.InstallError]:     File "/private/var/folders/8g/y5c2zpzd1rl3kyt__7kxk1p00000gn/T/pip-install-so9ryf2q/clickhouse-driver_5f155666511d4548aed9ad996a6662cb/setup.py", line 65, in <module>
[pipenv.exceptions.InstallError]:       extensions = cythonize(extensions, compiler_directives=compiler_directives)
[pipenv.exceptions.InstallError]:     File "/Users/aveline/.local/share/virtualenvs/misaka-D00KXp59/lib/python3.9/site-packages/Cython/Build/Dependencies.py", line 1116, in cythonize
[pipenv.exceptions.InstallError]:       cythonize_one(*args)
[pipenv.exceptions.InstallError]:     File "/Users/aveline/.local/share/virtualenvs/misaka-D00KXp59/lib/python3.9/site-packages/Cython/Build/Dependencies.py", line 1283, in cythonize_one
[pipenv.exceptions.InstallError]:       raise CompileError(None, pyx_file)
[pipenv.exceptions.InstallError]:   Cython.Compiler.Errors.CompileError: clickhouse_driver/columns/largeint.pyx
[pipenv.exceptions.InstallError]:   Compiling clickhouse_driver/bufferedreader.pyx because it depends on /Users/aveline/.local/share/virtualenvs/misaka-D00KXp59/lib/python3.9/site-packages/Cython/Includes/libc/string.pxd.
[pipenv.exceptions.InstallError]:   Compiling clickhouse_driver/bufferedwriter.pyx because it depends on /Users/aveline/.local/share/virtualenvs/misaka-D00KXp59/lib/python3.9/site-packages/Cython/Includes/libc/string.pxd.
[pipenv.exceptions.InstallError]:   Compiling clickhouse_driver/columns/largeint.pyx because it depends on /Users/aveline/.local/share/virtualenvs/misaka-D00KXp59/lib/python3.9/site-packages/Cython/Includes/libc/string.pxd.
[pipenv.exceptions.InstallError]:   Compiling clickhouse_driver/varint.pyx because it depends on /Users/aveline/.local/share/virtualenvs/misaka-D00KXp59/lib/python3.9/site-packages/Cython/Includes/libc/string.pxd.
[pipenv.exceptions.InstallError]:   [1/4] Cythonizing clickhouse_driver/bufferedreader.pyx
[pipenv.exceptions.InstallError]:   [2/4] Cythonizing clickhouse_driver/bufferedwriter.pyx
[pipenv.exceptions.InstallError]:   [3/4] Cythonizing clickhouse_driver/columns/largeint.pyx
[pipenv.exceptions.InstallError]:   ----------------------------------------
```