### PR TITLE
Fix python_requires to valid PEP 440 syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         'Documentation': 'https://clickhouse-driver.readthedocs.io',
     },
     packages=find_packages('.', exclude=['tests*']),
-    python_requires='>=3.4.*, <4',
+    python_requires='>=3.4, <4',
     install_requires=[
         'pytz',
         'tzlocal',


### PR DESCRIPTION
The existing python_requires valid of >=3.4.* is invalid and should be >=3.4. 

PEP440 only states that the wildcard suffix is used with [version matching ==](https://www.python.org/dev/peps/pep-0440/#version-matching). 

For now this seems to work fine with pip luckily but tools like poetry are a bit more strict in the interpretation and the upcoming version will error if they encounter this syntax. See also https://github.com/python-poetry/poetry/issues/4201.