### PR TITLE
export escape_params

### DIFF
--- a/clickhouse_driver/__init__.py
+++ b/clickhouse_driver/__init__.py
@@ -1,6 +1,7 @@
 
 from .client import Client
 from .dbapi import connect
+from .util.escape import escape_params
 
 
 VERSION = (0, 2, 4)


### PR DESCRIPTION
Since Python support f-string and other string interpolation method, clickhouse_driver can export `escape_params` function so that a user can escape inputs by themselves.

Also, if the input is a list, it's more convenient to escape outside the `execute` method.

Signed-off-by: tison <wander4096@gmail.com>