### PR TITLE
Add logging of failed queries

### DIFF
--- a/clickhouse_driver/result.py
+++ b/clickhouse_driver/result.py
@@ -126,7 +126,8 @@ class IterQueryResult(object):
 
 
 class QueryInfo(object):
-    def __init__(self):
+    def __init__(self, query):
+        self.query = query
         self.profile_info = BlockStreamProfileInfo()
         self.progress = Progress()
         self.elapsed = 0


### PR DESCRIPTION
## Background

When a query executed through `clickhouse-driver` fails, it can be tricky to diagnose the issue as the failed query is not always logged.

As an example, the runtime error
```
clickhouse_driver.errors.ServerException: Code: 62.
DB::Exception: Syntax error: failed at position 9 (')'): ). Unmatched parentheses: ). Stack trace:
```
is difficult to diagnose without seeing the malformed query (`SELECT 1)` in this case).

While it might be possible to find the failed query in the ClickHouse server error log (typically in `/var/log/clickhouse-server/clickhouse-server.err.log`), the user might not have permissions to read this.

This PR adds logging of failed queries to the `Client` class to help users with troubleshooting.

## Implementation notes

While it is possible to define logic outside the driver to log failed queries, I've found this surprisingly tricky to get right since

* The driver does not store the last executed query (`client.last_query` does not currently store the actual query string).
* Errors can arise after a call to `client.execute_iter` has returned an iterator, when you actually iterate through the iterator.