### PR TITLE
Add support for specifying server_hostname via SNI when connecting

### DIFF
--- a/clickhouse_driver/client.py
+++ b/clickhouse_driver/client.py
@@ -700,7 +700,8 @@ class Client(object):
                 kwargs[name] = asbool(value)
             elif name == 'ssl_version':
                 kwargs[name] = getattr(ssl, value)
-            elif name in ['ca_certs', 'ciphers', 'keyfile', 'certfile', 'server_hostname']:
+            elif name in ['ca_certs', 'ciphers', 'keyfile', 'certfile',
+                          'server_hostname']:
                 kwargs[name] = value
             elif name == 'alt_hosts':
                 kwargs['alt_hosts'] = value

--- a/clickhouse_driver/client.py
+++ b/clickhouse_driver/client.py
@@ -700,7 +700,7 @@ class Client(object):
                 kwargs[name] = asbool(value)
             elif name == 'ssl_version':
                 kwargs[name] = getattr(ssl, value)
-            elif name in ['ca_certs', 'ciphers', 'keyfile', 'certfile']:
+            elif name in ['ca_certs', 'ciphers', 'keyfile', 'certfile', 'server_hostname']:
                 kwargs[name] = value
             elif name == 'alt_hosts':
                 kwargs['alt_hosts'] = value

--- a/clickhouse_driver/connection.py
+++ b/clickhouse_driver/connection.py
@@ -82,6 +82,11 @@ class Connection(object):
     :param port: port ClickHouse server is bound to.
                  Defaults to ``9000`` if connection is not secured and
                  to ``9440`` if connection is secured.
+    :param server_hostname: Hostname to use in SSL Wrapper construction.
+                            Defaults to `None` which will send the passed
+                            host param during SSL initialization. This param
+                            may be used when connecting over an SSH tunnel
+                            to correctly identify the desired server via SNI.
     :param database: database connect to. Defaults to ``'default'``.
     :param user: database user. Defaults to ``'default'``.
     :param password: user's password. Defaults to ``''`` (no password).
@@ -122,7 +127,7 @@ class Connection(object):
     """
 
     def __init__(
-            self, host, port=None,
+            self, host, port=None, server_hostname=None,
             database=defines.DEFAULT_DATABASE,
             user=defines.DEFAULT_USER, password=defines.DEFAULT_PASSWORD,
             client_name=defines.CLIENT_NAME,
@@ -150,6 +155,7 @@ class Connection(object):
                 url = urlparse('clickhouse://' + host)
                 self.hosts.append((url.hostname, url.port or default_port))
 
+        self.server_hostname = server_hostname
         self.database = database
         self.user = user
         self.password = password
@@ -247,7 +253,7 @@ class Connection(object):
 
                 if self.secure_socket:
                     ssl_context = self._create_ssl_context(ssl_options)
-                    sock = ssl_context.wrap_socket(sock, server_hostname=host)
+                    sock = ssl_context.wrap_socket(sock, server_hostname=self.server_hostname or host)
 
                 sock.connect(sa)
                 return sock


### PR DESCRIPTION
This specifically allows connections to be made over SSH tunnels via separately setting the `server_hostname` when constructing the SSL wrapper. Without this, one would have to modify `/etc/hosts` to achieve the same effect which isn't always possible in all environments.