### PR TITLE
add numpy bool dtype support

### DIFF
--- a/clickhouse_driver/columns/numpy/boolcolumn.py
+++ b/clickhouse_driver/columns/numpy/boolcolumn.py
@@ -1,0 +1,8 @@
+import numpy as np
+
+from .base import NumpyColumn
+
+
+class NumpyBoolColumn(NumpyColumn):
+    dtype = np.dtype(np.bool_)
+    ch_type = 'Bool'

--- a/clickhouse_driver/columns/numpy/service.py
+++ b/clickhouse_driver/columns/numpy/service.py
@@ -7,6 +7,7 @@ from .intcolumn import (
     NumpyInt8Column, NumpyInt16Column, NumpyInt32Column, NumpyInt64Column,
     NumpyUInt8Column, NumpyUInt16Column, NumpyUInt32Column, NumpyUInt64Column
 )
+from .boolcolumn import NumpyBoolColumn
 from .lowcardinalitycolumn import create_numpy_low_cardinality_column
 from .stringcolumn import create_string_column
 from .tuplecolumn import create_tuple_column
@@ -16,7 +17,8 @@ column_by_type = {c.ch_type: c for c in [
     NumpyDateColumn,
     NumpyFloat32Column, NumpyFloat64Column,
     NumpyInt8Column, NumpyInt16Column, NumpyInt32Column, NumpyInt64Column,
-    NumpyUInt8Column, NumpyUInt16Column, NumpyUInt32Column, NumpyUInt64Column
+    NumpyUInt8Column, NumpyUInt16Column, NumpyUInt32Column, NumpyUInt64Column,
+    NumpyBoolColumn
 ]}
 
 

--- a/tests/numpy/columns/test_bool.py
+++ b/tests/numpy/columns/test_bool.py
@@ -1,0 +1,67 @@
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
+from tests.numpy.testcase import NumpyBaseTestCase
+
+
+class BoolTestCase(NumpyBaseTestCase):
+    n = 10
+
+    def check_result(self, rv, col_type):
+        self.assertArraysEqual(rv[0], np.array(range(self.n)))
+        self.assertEqual(rv[0].dtype, col_type)
+
+    def get_query(self, ch_type):
+        with self.create_table('a {}'.format(ch_type)):
+            data = [np.array(range(self.n))]
+            self.client.execute(
+                'INSERT INTO test (a) VALUES', data, columnar=True
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(
+                inserted, '\n'.join(str(x) for x in data[0]) + '\n'
+            )
+            return self.client.execute(query, columnar=True)
+
+    def test_bool(self):
+        rv = self.get_query('Bool')
+        self.check_result(rv, np.bool_)
+
+    def test_insert_nan_into_non_nullable(self):
+        with self.create_table('a Bool'):
+            data = [
+                np.array([True, np.nan], dtype=object)
+            ]
+            self.client.execute(
+                'INSERT INTO test (a) VALUES', data, columnar=True
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(
+                inserted,
+                'true\nfalse\n'
+            )
+
+            inserted = self.client.execute(query, columnar=True)
+            self.assertArraysEqual(inserted[0], np.array([True, 0]))
+            self.assertEqual(inserted[0].dtype, np.int32)
+
+    def test_nullable(self):
+        with self.create_table('a Nullable(Bool)'):
+            data = [np.array([False, None, True, None, False])]
+            self.client.execute(
+                'INSERT INTO test (a) VALUES', data, columnar=True
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(inserted, 'false\n\\N\ntrue\n\\N\nfalse\n')
+
+            inserted = self.client.execute(query, columnar=True)
+            self.assertArraysEqual(inserted[0], data[0])
+            self.assertEqual(inserted[0].dtype, object)

--- a/tests/numpy/columns/test_bool.py
+++ b/tests/numpy/columns/test_bool.py
@@ -8,6 +8,8 @@ from tests.numpy.testcase import NumpyBaseTestCase
 
 class BoolTestCase(NumpyBaseTestCase):
     n = 10
+    # https://clickhouse.com/docs/en/whats-new/changelog/2021
+    required_server_version = (21, 12, 0)
 
     def check_result(self, rv, col_type):
         data = (np.array(range(self.n)) % 2).astype(bool)

--- a/tests/numpy/columns/test_bool.py
+++ b/tests/numpy/columns/test_bool.py
@@ -10,12 +10,13 @@ class BoolTestCase(NumpyBaseTestCase):
     n = 10
 
     def check_result(self, rv, col_type):
-        self.assertArraysEqual(rv[0], np.array(range(self.n)))
+        data = (np.array(range(self.n)) % 2).astype(bool)
+        self.assertArraysEqual(rv[0], data)
         self.assertEqual(rv[0].dtype, col_type)
 
     def get_query(self, ch_type):
         with self.create_table('a {}'.format(ch_type)):
-            data = [np.array(range(self.n))]
+            data = [(np.array(range(self.n)) % 2).astype(bool)]
             self.client.execute(
                 'INSERT INTO test (a) VALUES', data, columnar=True
             )
@@ -23,7 +24,7 @@ class BoolTestCase(NumpyBaseTestCase):
             query = 'SELECT * FROM test'
             inserted = self.emit_cli(query)
             self.assertEqual(
-                inserted, '\n'.join(str(x) for x in data[0]) + '\n'
+                inserted, '\n'.join(str(x).lower() for x in data[0]) + '\n'
             )
             return self.client.execute(query, columnar=True)
 
@@ -49,7 +50,7 @@ class BoolTestCase(NumpyBaseTestCase):
 
             inserted = self.client.execute(query, columnar=True)
             self.assertArraysEqual(inserted[0], np.array([True, 0]))
-            self.assertEqual(inserted[0].dtype, np.int32)
+            self.assertEqual(inserted[0].dtype, np.bool_)
 
     def test_nullable(self):
         with self.create_table('a Nullable(Bool)'):


### PR DESCRIPTION
Adds bool support for numpy

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code. (**N/A**)
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
