### PR TITLE
dont raise on dataframe insert if columns are superset of schema

### DIFF
--- a/clickhouse_driver/client.py
+++ b/clickhouse_driver/client.py
@@ -453,11 +453,11 @@ class Client(object):
             rv = None
             if sample_block:
                 columns = [x[0] for x in sample_block.columns_with_types]
-                if len(columns) != dataframe.shape[1]:
-                    msg = 'Expected {} columns, got {}'.format(
-                        len(columns), dataframe.shape[1]
-                    )
-                    raise ValueError(msg)
+                # raise if any columns are missing from the dataframe
+                diff = set(columns) - set(dataframe.columns)
+                if len(diff):
+                    msg = "DataFrame missing required columns: {}"
+                    raise ValueError(msg.format(list(diff)))
 
                 data = [dataframe[column].values for column in columns]
                 rv = self.send_data(sample_block, data, columnar=True)

--- a/tests/numpy/test_generic.py
+++ b/tests/numpy/test_generic.py
@@ -148,12 +148,22 @@ class DataFrameTestCase(NumpyBaseTestCase):
 
         self.assertEqual(df.shape, (0, 2))
 
-    def test_data_less_columns_then_expected(self):
+    def test_data_less_columns_than_expected(self):
         with self.create_table('a Int8, b Int8'):
             with self.assertRaises(ValueError) as e:
                 df = pd.DataFrame([1, 2, 3], columns=['a'])
                 self.client.insert_dataframe('INSERT INTO test VALUES', df)
-            self.assertEqual(str(e.exception), 'Expected 2 columns, got 1')
+            expected = "DataFrame missing required columns: ['b']"
+            self.assertEqual(str(e.exception), expected)
+
+
+    def test_data_different_columns_than_expected(self):
+        with self.create_table('a Int8, b Int8'):
+            with self.assertRaises(ValueError) as e:
+                df = pd.DataFrame([[1, 2], [3, 4]], columns=['a', 'c'])
+                self.client.insert_dataframe('INSERT INTO test VALUES', df)
+            expected = "DataFrame missing required columns: ['b']"    
+            self.assertEqual(str(e.exception), expected)
 
 
 class NoNumPyTestCase(BaseTestCase):

--- a/tests/numpy/test_generic.py
+++ b/tests/numpy/test_generic.py
@@ -156,13 +156,12 @@ class DataFrameTestCase(NumpyBaseTestCase):
             expected = "DataFrame missing required columns: ['b']"
             self.assertEqual(str(e.exception), expected)
 
-
     def test_data_different_columns_than_expected(self):
         with self.create_table('a Int8, b Int8'):
             with self.assertRaises(ValueError) as e:
                 df = pd.DataFrame([[1, 2], [3, 4]], columns=['a', 'c'])
                 self.client.insert_dataframe('INSERT INTO test VALUES', df)
-            expected = "DataFrame missing required columns: ['b']"    
+            expected = "DataFrame missing required columns: ['b']"
             self.assertEqual(str(e.exception), expected)
 
 


### PR DESCRIPTION
Fixes:
- No longer raises `ValueError` on `insert_dataframe` when DataFrame columns are a superset of schema columns

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
