### PR TITLE
Feature/err codes as enum

### DIFF
--- a/clickhouse_driver/errors.py
+++ b/clickhouse_driver/errors.py
@@ -1,6 +1,8 @@
+import enum
 
 
-class ErrorCodes(object):
+@enum.unique
+class ErrorCodes(enum.Enum):
     UNSUPPORTED_METHOD = 1
     UNSUPPORTED_PARAMETER = 2
     UNEXPECTED_END_OF_FILE = 3
@@ -399,51 +401,51 @@ class ServerException(Error):
 
 
 class LogicalError(Error):
-    code = ErrorCodes.LOGICAL_ERROR
+    code = ErrorCodes.LOGICAL_ERROR.value
 
 
 class UnknownTypeError(Error):
-    code = ErrorCodes.UNKNOWN_TYPE
+    code = ErrorCodes.UNKNOWN_TYPE.value
 
 
 class ChecksumDoesntMatchError(Error):
-    code = ErrorCodes.CHECKSUM_DOESNT_MATCH
+    code = ErrorCodes.CHECKSUM_DOESNT_MATCH.value
 
 
 class TypeMismatchError(Error):
-    code = ErrorCodes.TYPE_MISMATCH
+    code = ErrorCodes.TYPE_MISMATCH.value
 
 
 class UnknownCompressionMethod(Error):
-    code = ErrorCodes.UNKNOWN_COMPRESSION_METHOD
+    code = ErrorCodes.UNKNOWN_COMPRESSION_METHOD.value
 
 
 class TooLargeStringSize(Error):
-    code = ErrorCodes.TOO_LARGE_STRING_SIZE
+    code = ErrorCodes.TOO_LARGE_STRING_SIZE.value
 
 
 class NetworkError(Error):
-    code = ErrorCodes.NETWORK_ERROR
+    code = ErrorCodes.NETWORK_ERROR.value
 
 
 class SocketTimeoutError(Error):
-    code = ErrorCodes.SOCKET_TIMEOUT
+    code = ErrorCodes.SOCKET_TIMEOUT.value
 
 
 class UnexpectedPacketFromServerError(Error):
-    code = ErrorCodes.UNEXPECTED_PACKET_FROM_SERVER
+    code = ErrorCodes.UNEXPECTED_PACKET_FROM_SERVER.value
 
 
 class UnknownPacketFromServerError(Error):
-    code = ErrorCodes.UNKNOWN_PACKET_FROM_SERVER
+    code = ErrorCodes.UNKNOWN_PACKET_FROM_SERVER.value
 
 
 class CannotParseUuidError(Error):
-    code = ErrorCodes.CANNOT_PARSE_UUID
+    code = ErrorCodes.CANNOT_PARSE_UUID.value
 
 
 class CannotParseDomainError(Error):
-    code = ErrorCodes.CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING
+    code = ErrorCodes.CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING.value
 
 
 class PartiallyConsumedQueryError(Error):

--- a/tests/columns/test_nullable.py
+++ b/tests/columns/test_nullable.py
@@ -31,7 +31,7 @@ class NullableTestCase(BaseTestCase):
                 'CREATE TABLE test ({}) ''ENGINE = Memory'.format(columns)
             )
 
-        self.assertEqual(e.exception.code, ErrorCodes.ILLEGAL_TYPE_OF_ARGUMENT)
+        self.assertEqual(e.exception.code, ErrorCodes.ILLEGAL_TYPE_OF_ARGUMENT.value)
 
     def test_nullable_array(self):
         columns = 'a Nullable(Array(Nullable(Array(Nullable(Int32)))))'
@@ -41,4 +41,4 @@ class NullableTestCase(BaseTestCase):
                 'CREATE TABLE test ({}) ''ENGINE = Memory'.format(columns)
             )
 
-        self.assertEqual(e.exception.code, ErrorCodes.ILLEGAL_TYPE_OF_ARGUMENT)
+        self.assertEqual(e.exception.code, ErrorCodes.ILLEGAL_TYPE_OF_ARGUMENT.value)

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -82,7 +82,7 @@ class MiscCompressionTestCase(TestCase):
             get_compressor_cls('hello')
 
         self.assertEqual(
-            e.exception.code, errors.ErrorCodes.UNKNOWN_COMPRESSION_METHOD
+            e.exception.code, errors.ErrorCodes.UNKNOWN_COMPRESSION_METHOD.value
         )
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -91,7 +91,7 @@ class SettingTestCase(BaseTestCase):
         with self.created_client(settings_is_important=True) as client:
             with self.assertRaises(ServerException) as e:
                 client.execute('SELECT 1', settings=settings)
-            self.assertEqual(e.exception.code, ErrorCodes.UNKNOWN_SETTING)
+            self.assertEqual(e.exception.code, ErrorCodes.UNKNOWN_SETTING.value)
 
     def test_client_settings(self):
         settings = {'max_query_size': 142}
@@ -154,8 +154,8 @@ class LimitsTestCase(BaseTestCase):
         # New servers return TOO_MANY_ROWS_OR_BYTES.
         # Old servers return TOO_MANY_ROWS.
         error_codes = {
-            ErrorCodes.TOO_MANY_ROWS_OR_BYTES,
-            ErrorCodes.TOO_MANY_ROWS
+            ErrorCodes.TOO_MANY_ROWS_OR_BYTES.value,
+            ErrorCodes.TOO_MANY_ROWS.value
         }
         self.assertIn(e.exception.code, error_codes)
 


### PR DESCRIPTION
I find the var name assigned with error code useful for my project purposes.
Using Enum one can get both the name and its matching error code.
Additionally - using the unique decorator it's assured that no error code is duplicated.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
