### PR TITLE
add support for time parameter substitution

### DIFF
--- a/clickhouse_driver/util/escape.py
+++ b/clickhouse_driver/util/escape.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, time
 from enum import Enum
 from uuid import UUID
 
@@ -37,6 +37,9 @@ def escape_param(item, context):
 
     elif isinstance(item, date):
         return "'%s'" % item.strftime('%Y-%m-%d')
+
+    elif isinstance(item, time):
+        return "'%s'" % item.strftime('%H:%M:%S')
 
     elif isinstance(item, str):
         return "'%s'" % ''.join(escape_chars_map.get(c, c) for c in item)

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
-from datetime import date, datetime
+from datetime import date, datetime, time
 from decimal import Decimal
 from unittest.mock import Mock
 from uuid import UUID
@@ -52,6 +52,15 @@ class ParametersSubstitutionTestCase(BaseTestCase):
 
         rv = self.client.execute(tpl, params)
         self.assertEqual(rv, [(d, )])
+
+    def test_time(self):
+        t = time(8, 20, 15)
+        params = {'x': t}
+
+        self.assert_subst(self.single_tpl, params, "SELECT '08:20:15'")
+
+        rv = self.client.execute(self.single_tpl, params)
+        self.assertEqual(rv, [('08:20:15', )])
 
     def test_datetime(self):
         dt = datetime(2017, 10, 16, 0, 18, 50)


### PR DESCRIPTION
<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #359 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
