### PR TITLE
Fix for issue #363: exception raises on insert to a nullable low cardinality columns

### DIFF
--- a/tests/columns/test_low_cardinality.py
+++ b/tests/columns/test_low_cardinality.py
@@ -65,6 +65,15 @@ class LowCardinalityTestCase(BaseTestCase):
             inserted = self.client.execute(query)
             self.assertEqual(inserted, data)
 
+    def test_nullable_date(self):
+        with self.create_table('a LowCardinality(Nullable(Date))'):
+            data = [(date(2023, 4, 1), ), (None, ), (date(1970, 1, 1), )]
+            self.client.execute('INSERT INTO test (a) VALUES', data)
+
+            query = 'SELECT * FROM test'
+            inserted = self.client.execute(query)
+            self.assertEqual(inserted, data)
+
     def test_float(self):
         with self.create_table('a LowCardinality(Float)'):
             data = [(float(x),) for x in range(300)]


### PR DESCRIPTION
- fixes #363 

Checklist:

- [x ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x ] Add or update relevant docs, in the docs folder and in code.
- [x ] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x ] Run `flake8` and fix issues.
- [x ] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
