### PR TITLE
fix client.insert_dataframe() for tables with tuple columns with acceptance of `numpy.ndarray`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- fix `client.insert_dataframe()` behaviour for tables with tuple columns. Solves issues [#356](https://github.com/mymarilyn/clickhouse-driver/issues/356) and [#417](https://github.com/mymarilyn/clickhouse-driver/issues/417). Pull request [#426](https://github.com/mymarilyn/clickhouse-driver/pull/426) by [stankudrow](https://github.com/stankudrow/).
+
 ## [0.2.7] - 2024-02-20
 ### Added
 - Wheels for Python 3.12.

--- a/clickhouse_driver/client.py
+++ b/clickhouse_driver/client.py
@@ -539,10 +539,19 @@ class Client(object):
                 # raise if any columns are missing from the dataframe
                 diff = set(columns) - set(dataframe.columns)
                 if len(diff):
-                    msg = "DataFrame missing required columns: {}"
-                    raise ValueError(msg.format(list(diff)))
+                    raise ValueError(
+                        f"DataFrame has missing required columns: {list(diff)}"
+                    )
 
-                data = [dataframe[column].values for column in columns]
+                # TODO: to find a more pandas-idiomatic way
+                data = []
+                for column in columns:
+                    column_values = dataframe[column].values
+                    for idx, col_vals in enumerate(column_values):
+                        if isinstance(col_vals, dict):
+                            column_values[idx] = tuple(col_vals.values())
+                    data.append(column_values)
+
                 rv = self.send_data(sample_block, data, columnar=True)
                 self.receive_end_of_query()
 

--- a/clickhouse_driver/util/helpers.py
+++ b/clickhouse_driver/util/helpers.py
@@ -1,12 +1,27 @@
 from itertools import islice, tee
 
+try:
+    import numpy as np
+
+    CHECK_NUMPY_TYPES = True
+except ImportError:
+    CHECK_NUMPY_TYPES = False
+
+
+def _check_sequence_to_be_an_expected_iterable(seq):
+    expected = [list, tuple]
+    if CHECK_NUMPY_TYPES:
+        expected.append(np.ndarray)
+    return isinstance(seq, tuple(expected))
+
 
 def chunks(seq, n):
     # islice is MUCH slower than slice for lists and tuples.
-    if isinstance(seq, (list, tuple)):
+    if _check_sequence_to_be_an_expected_iterable(seq):
         i = 0
         item = seq[i:i+n]
-        while item:
+        # DeprecationWarning: The truth value of an empty array is ambiguous.
+        while len(item):
             yield list(item)
             i += n
             item = seq[i:i+n]
@@ -27,10 +42,10 @@ def pairwise(iterable):
 
 def column_chunks(columns, n):
     for column in columns:
-        if not isinstance(column, (list, tuple)):
+        if not _check_sequence_to_be_an_expected_iterable(column):
             raise TypeError(
-                'Unsupported column type: {}. list or tuple is expected.'
-                .format(type(column))
+                f"Unsupported column type: {type(column)}. "
+                "Expected list, tuple or numpy.ndarray"
             )
 
     # create chunk generator for every column

--- a/tests/numpy/test_insert.py
+++ b/tests/numpy/test_insert.py
@@ -1,0 +1,92 @@
+from unittest import skipIf
+
+try:
+    import pandas as pd
+
+    PANDAS_IMPORTED = True
+except ImportError:
+    PANDAS_IMPORTED = False
+
+#from tests.testcase import BaseTestCase
+from tests.numpy.testcase import NumpyBaseTestCase
+
+
+@skipIf(not PANDAS_IMPORTED, reason="pandas cannot be imported")
+class InsertDataFrameTestCase(NumpyBaseTestCase):
+    """The test suite on pandas.DataFrame insertions."""
+
+    def test_insert_ndarray_acceptance(self):
+        """https://github.com/mymarilyn/clickhouse-driver/issues/356"""
+
+        with self.create_table("status String"):
+            df = pd.DataFrame(columns=["status"])
+            rv = self.client.insert_dataframe("INSERT INTO test VALUES", df)
+            assert rv == 0
+
+    def test_insert_the_frame_with_dict_rows(self):
+        """https://github.com/mymarilyn/clickhouse-driver/issues/417"""
+
+        with self.create_table("a Tuple(x Float32, y Float32)"):
+            df = pd.DataFrame(
+                [
+                    {
+                        "a": (0.1, 0.1),
+                    },
+                ]
+            )
+            self.client.insert_dataframe("INSERT INTO test VALUES", df)
+
+            df = pd.DataFrame(
+                [
+                    {
+                        "a": {"x": 0.2, "y": 0.2},
+                    },
+                ]
+            )
+            self.client.insert_dataframe("INSERT INTO test VALUES", df)
+
+            df = pd.DataFrame(
+                [
+                    {
+                        "a": {"x": 0.3, "y": 0.3},
+                    },
+                ]
+            )
+            self.client.insert_dataframe(
+                "INSERT INTO test VALUES", df, settings={"use_numpy": False}
+            )
+
+            df = pd.DataFrame(
+                [
+                    {
+                        "a": (0.4, 0.4),
+                    },
+                ]
+            )
+            self.client.execute("INSERT INTO test VALUES", df.values.tolist())
+
+            df = pd.DataFrame(
+                [
+                    {
+                        "a": (0.5, 0.5),
+                    },
+                ]
+            )
+            self.client.execute(
+                "INSERT INTO test VALUES",
+                df.values.tolist(),
+                settings={"use_numpy": False},
+            )
+
+            query = "SELECT * FROM test"
+            result = self.client.execute(query)
+            # normalising the result
+            result = [
+                tuple(map(lambda val: round(val, 1), row[0])) for row in result
+            ]
+
+            # to enforce the order and prevent the test from failing
+            self.assertEqual(
+                sorted(result),
+                [(0.1, 0.1), (0.2, 0.2), (0.3, 0.3), (0.4, 0.4), (0.5, 0.5)],
+            )

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -1,18 +1,9 @@
 from datetime import date
-from unittest import skipIf
 
 from tests.testcase import BaseTestCase
 from clickhouse_driver import errors
 from clickhouse_driver.errors import ServerException
 from tests.util import require_server_version
-
-
-try:
-    import pandas as pd
-
-    PANDAS_IMPORTED = True
-except ImportError:
-    PANDAS_IMPORTED = False
 
 
 class InsertTestCase(BaseTestCase):
@@ -242,83 +233,3 @@ class InsertColumnarTestCase(BaseTestCase):
                 )
 
             self.assertIn("Expected list, tuple or numpy.ndarray", str(e.exception))
-
-
-@skipIf(not PANDAS_IMPORTED, reason="pandas cannot be imported")
-class InsertDataFrameTestCase(BaseTestCase):
-    """The test suite on pandas.DataFrame insertions."""
-
-    def test_insert_ndarray_acceptance(self):
-        """https://github.com/mymarilyn/clickhouse-driver/issues/356"""
-
-        with self.create_table("status String"):
-            df = pd.DataFrame(columns=["status"])
-            self.client.insert_dataframe("INSERT INTO test VALUES", df)
-
-    def test_insert_the_frame_with_dict_rows(self):
-        """https://github.com/mymarilyn/clickhouse-driver/issues/417"""
-
-        with self.create_table("a Tuple(x Float32, y Float32)"):
-            df = pd.DataFrame(
-                [
-                    {
-                        "a": (0.1, 0.1),
-                    },
-                ]
-            )
-            self.client.insert_dataframe("INSERT INTO test VALUES", df)
-
-            df = pd.DataFrame(
-                [
-                    {
-                        "a": {"x": 0.2, "y": 0.2},
-                    },
-                ]
-            )
-            self.client.insert_dataframe("INSERT INTO test VALUES", df)
-
-            df = pd.DataFrame(
-                [
-                    {
-                        "a": {"x": 0.3, "y": 0.3},
-                    },
-                ]
-            )
-            self.client.insert_dataframe(
-                "INSERT INTO test VALUES", df, settings={"use_numpy": False}
-            )
-
-            df = pd.DataFrame(
-                [
-                    {
-                        "a": (0.4, 0.4),
-                    },
-                ]
-            )
-            self.client.execute("INSERT INTO test VALUES", df.values.tolist())
-
-            df = pd.DataFrame(
-                [
-                    {
-                        "a": (0.5, 0.5),
-                    },
-                ]
-            )
-            self.client.execute(
-                "INSERT INTO test VALUES",
-                df.values.tolist(),
-                settings={"use_numpy": False},
-            )
-
-            query = "SELECT * FROM test"
-            result = self.client.execute(query)
-            # normalising the result
-            result = [
-                tuple(map(lambda val: round(val, 1), row[0])) for row in result
-            ]
-
-            # sorted for ensuring the order - data races
-            self.assertEqual(
-                sorted(result),
-                [(0.1, 0.1), (0.2, 0.2), (0.3, 0.3), (0.4, 0.4), (0.5, 0.5)],
-            )


### PR DESCRIPTION
- fixes
  - #356
  - #417

- reconsiders the PR #425

Packages:

- black : 24.2.0
- clickhouse-cityhash : 1.0.2.4
- clickhouse-driver : 0.2.7
- Cython : 3.0.9
- flake8 : 7.0.0
- freezegun : 1.4.0
- lz4 : 4.3.3
- mypy : 1.9.0
- numpy : 1.26.4
- pandas : 2.2.1
- parametrized : 66.0.2 (there is the latest 66.0.3 -> to be removed in favour of `pytest.mark.parametrize`)
- pytest : 7.4.4
- ruff : 0.3.2
- zstd : 1.5.5.1

Checklist:

- [x] Add tests that demonstrate the correct behaviour of the change.
- [ ] Add or update relevant docs, in the docs folder and in code -> no docs to change.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues;
- [x] Run `pytest` no tests failed. See the [dev docs](https://clickhouse-driver.readthedocs.io/en/latest/development.html).
- [x] Update CHANGELOG.md
