### PR TITLE
Add profile events support

### DIFF
--- a/clickhouse_driver/client.py
+++ b/clickhouse_driver/client.py
@@ -264,6 +264,10 @@ class Client(object):
             self.last_query.store_profile(packet.profile_info)
             return True
 
+        elif packet.type == ServerPacketTypes.PROFILE_EVENTS:
+            self.last_query.store_profile_events(packet)
+            return True
+
         else:
             return True
 
@@ -691,7 +695,7 @@ class Client(object):
                 pass
 
             elif packet.type == ServerPacketTypes.PROFILE_EVENTS:
-                self.last_query.store_profile(packet.profile_info)
+                self.last_query.store_profile_events(packet)
 
             else:
                 message = self.connection.unexpected_packet_message(
@@ -734,7 +738,7 @@ class Client(object):
             packet = self.connection.receive_packet()
 
             if packet.type == ServerPacketTypes.PROFILE_EVENTS:
-                self.last_query.store_profile(packet.profile_info)
+                self.last_query.store_profile_events(packet)
                 break
 
             elif packet.type == ServerPacketTypes.PROGRESS:

--- a/clickhouse_driver/result.py
+++ b/clickhouse_driver/result.py
@@ -130,6 +130,7 @@ class QueryInfo(object):
         self.profile_info = BlockStreamProfileInfo()
         self.progress = Progress()
         self.elapsed = 0
+        self.stats = {}
 
     def store_profile(self, profile_info):
         self.profile_info = profile_info
@@ -142,3 +143,14 @@ class QueryInfo(object):
 
     def store_elapsed(self, elapsed):
         self.elapsed = elapsed
+
+    def store_profile_events(self, packet):
+        data = QueryResult([packet]).get_result()
+        column_names = [i[0] for i in packet.block.columns_with_types]
+        for row in data:
+            item = dict(zip(column_names, row))
+            name = item.get('name', '')
+            if item['type'] == 'increment':
+                self.stats[name] = self.stats.get(name, 0) + item['value']
+            elif item['type'] == 'gauge':
+                self.stats[name] = item['value']


### PR DESCRIPTION
- fixes #451

Adds support of profile events on native protocol. There are many different parameters inside like network timings, locks, memory usage, that may be very helpful for debug and monitoring queries.

Not sure is it needed to update docs.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
