### PR TITLE
Up ClientInfo getuser exception handling to Py3.13

### DIFF
--- a/clickhouse_driver/clientinfo.py
+++ b/clickhouse_driver/clientinfo.py
@@ -39,7 +39,7 @@ class ClientInfo(object):
 
         try:
             self.os_user = getpass.getuser()
-        except KeyError:
+        except OSError:
             self.os_user = ''
         self.client_hostname = socket.gethostname()
         self.client_name = client_name


### PR DESCRIPTION
getuser() returns OSError in replacement of both ImportError, KeyError [since Python 3.13](https://docs.python.org/3/library/getpass.html#getpass.getuser)
