### PR TITLE
check for empty strings in prepare_items

### DIFF
--- a/clickhouse_driver/columns/base.py
+++ b/clickhouse_driver/columns/base.py
@@ -117,7 +117,7 @@ class Column(object):
 
         nulls_map = [False] * len(items) if self.nullable else None
         for i, x in enumerate(items):
-            if x is None:
+            if x is None or x == '':
                 if nullable:
                     nulls_map[i] = True
                     x = null_value


### PR DESCRIPTION
if a column is nullable then treat empty strings as Null values.

- fixes #487 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [ ] Run `flake8` and fix issues.
- [ ] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
