### PR TITLE
JSON -> Object('json')

### DIFF
--- a/tests/columns/test_json.py
+++ b/tests/columns/test_json.py
@@ -13,7 +13,11 @@ class JSONTestCase(BaseTestCase):
         return {'allow_experimental_object_type': 1}
 
     def test_simple(self):
-        rv = self.client.execute("SELECT '{\"bb\": {\"cc\": [255, 1]}}'::Object('json')")
+        rv = self.client.execute(
+            """
+            SELECT '{\"bb\": {\"cc\": [255, 1]}}'::Object('json')
+            """,
+        )
         self.assertEqual(rv, [({'bb': {'cc': [255, 1]}},)])
 
     def test_from_table(self):


### PR DESCRIPTION
Before ClickHouse 24.8, the syntax and support for the JSON data type referred to a different, now deprecated, implementation: Object('json'). In earlier versions, using JSON as a column type or casting to JSON would actually use the Object('json') type if the setting use_json_alias_for_old_object_type was enabled. This allowed queries like:
```sql
SELECT '{"bb": {"cc": [255, 1]}}'::JSON;
```
to work, but under the hood, this was not the new JSON type introduced in 24.8—it was the old Object('json') type, which is now deprecated and not production-ready. The new JSON type, with improved features and performance, was introduced as an experimental feature in 24.8 and is production-ready from 25.3 onward [Object data type](https://clickhouse.com/docs/sql-reference/data-types/object-data-type) [JSON Data Type](https://clickhouse.com/docs/sql-reference/data-types/newjson) [use_json_alias_for_old_object_type](https://clickhouse.com/docs/operations/settings/settings#use_json_alias_for_old_object_type).

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
