### PR TITLE
ci: Publish tagged releases to PyPI via Trusted Publishing

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -210,6 +210,12 @@ jobs:
           draft: true
           tag: Linux
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v4
+        name: Store wheels
+        if: ${{ github.ref_type == 'tag' }}
+        with:
+          name: dist-linux
+          path: wheelhouse/*.whl
 
   wheels-macos:
     name: Wheels for OS X
@@ -249,6 +255,12 @@ jobs:
           draft: true
           tag: OS X
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v4
+        name: Store wheels
+        if: ${{ github.ref_type == 'tag' }}
+        with:
+          name: dist-macos
+          path: wheelhouse/*.whl
 
   wheels-windows:
     name: Wheels for Windows
@@ -289,6 +301,12 @@ jobs:
           draft: true
           tag: Windows
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v4
+        name: Store wheels
+        if: ${{ github.ref_type == 'tag' }}
+        with:
+          name: dist-windows
+          path: wheelhouse/*.whl
 
   wheels-linux-non-x86:
     name: Wheels for Linux non-x86
@@ -340,3 +358,52 @@ jobs:
           draft: true
           tag: Linux non-x86
           token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v4
+        name: Store wheels
+        if: ${{ github.ref_type == 'tag' }}
+        with:
+          name: dist-linux-${{ matrix.arch }}
+          path: wheelhouse/*.whl
+
+  sdist:
+    name: Source distribution
+    needs: valgrind
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Build sdist
+        run: |
+          pip install --upgrade pip build
+          python -m build --sdist
+      - uses: actions/upload-artifact@v4
+        name: Store sdist
+        if: ${{ github.ref_type == 'tag' }}
+        with:
+          name: dist-sdist
+          path: dist/*.tar.gz
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: ${{ github.ref_type == 'tag' }}
+    needs:
+      - sdist
+      - wheels-linux
+      - wheels-macos
+      - wheels-windows
+      - wheels-linux-non-x86
+    runs-on: ubuntu-22.04
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          merge-multiple: true
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION

Adds an automated PyPI release path using [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC).
