### PR TITLE
build: Require clickhouse-cityhash 1.0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Native `JSON` support. Solves issue [#473](https://github.com/mymarilyn/clickhouse-driver/issues/473) and [#460](https://github.com/mymarilyn/clickhouse-driver/issues/460). Pull request [#503](https://github.com/mymarilyn/clickhouse-driver/pull/503/) by [khvn26](https://github.com/khvn26), [gsergey418](https://github.com/gsergey418).
+- Minimum `clickhouse-cityhash` version raised to 1.0.2.6: first release that builds on Python 3.13+.
 
 ## [0.2.10] - 2026-10-10
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -130,9 +130,9 @@ setup(
         'lz4': [
             'lz4<=3.0.1; implementation_name=="pypy"',
             'lz4; implementation_name!="pypy"',
-            'clickhouse-cityhash>=1.0.2.1'
+            'clickhouse-cityhash>=1.0.2.6'
         ],
-        'zstd': ['zstd', 'clickhouse-cityhash>=1.0.2.1'],
+        'zstd': ['zstd', 'clickhouse-cityhash>=1.0.2.6'],
         'numpy': ['numpy>=1.12.0', 'pandas>=0.24.0']
     },
     test_suite='pytest'

--- a/testsrequire.py
+++ b/testsrequire.py
@@ -8,7 +8,7 @@ tests_require = [
     'parameterized',
     'freezegun',
     'zstd',
-    'clickhouse-cityhash>=1.0.2.1'
+    'clickhouse-cityhash>=1.0.2.6'
 ]
 
 if sys.implementation.name == 'pypy':


### PR DESCRIPTION
Closes #474.

Raises the `clickhouse-cityhash` floor in the `lz4` and `zstd` extras (and the test requirements) from 1.0.2.1 to 1.0.2.6.

1.0.2.6 is the first release that builds on Python 3.13+ (xzkostyan/clickhouse-cityhash#6). The driver ships cp313/cp314 wheels, so without the raised floor a resolver can pick an older cityhash sdist on those Pythons and fail at build time.
