### PR TITLE
test: Fix flaky coverage

### DIFF
--- a/tests/columns/test_sparse.py
+++ b/tests/columns/test_sparse.py
@@ -1,7 +1,11 @@
 from datetime import date
+from io import BytesIO
+from unittest import TestCase
 
 from tests.testcase import BaseTestCase
 from clickhouse_driver import errors
+from clickhouse_driver.columns.base import SparseSerialization
+from clickhouse_driver.varint import write_varint
 
 ErrorCodes = errors.ErrorCodes
 
@@ -124,3 +128,49 @@ class SparseTestCase(BaseTestCase):
 
             inserted = self.client.execute(query)
             self.assertEqual(inserted, data)
+
+
+class FakeColumn(object):
+    null_value = 0
+    after_read_items = None
+
+
+class SparseSerializationTestCase(TestCase):
+    # Sending sparse blocks is the server's choice; test directly.
+
+    END_OF_GRANULE_FLAG = 1 << 62
+
+    def make_buf(self, group_sizes):
+        buf = BytesIO()
+        for size in group_sizes:
+            write_varint(size, buf)
+        buf.seek(0)
+        buf.read_one = lambda: ord(buf.read(1))
+        return buf
+
+    def test_read_and_apply_sparse(self):
+        serialization = SparseSerialization(FakeColumn())
+
+        # Non-default items at positions 3 and 7 of [0,0,5,0,0,0,7,0].
+        buf = self.make_buf([2, 3, self.END_OF_GRANULE_FLAG | 1])
+        n_items = serialization.read_sparse(8, buf)
+
+        self.assertEqual(n_items, 2)
+        self.assertEqual(serialization.sparse_indexes, [3, 7])
+        self.assertEqual(serialization.items_total, 9)
+        self.assertEqual(
+            serialization.apply_sparse([5, 7]),
+            [0, 0, 5, 0, 0, 0, 7, 0]
+        )
+
+    def test_apply_sparse_with_after_read_items(self):
+        column = FakeColumn()
+        column.after_read_items = lambda items, nulls_map=None: \
+            tuple(x + 100 for x in items)
+        serialization = SparseSerialization(column)
+
+        buf = self.make_buf([0, self.END_OF_GRANULE_FLAG | 1])
+        n_items = serialization.read_sparse(3, buf)
+
+        self.assertEqual(n_items, 1)
+        self.assertEqual(serialization.apply_sparse([105]), [105, 100])

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -54,7 +54,10 @@ class BlocksTestCase(BaseTestCase):
 
             query = 'SELECT * FROM test ORDER BY a'
 
-            inserted = self.client.execute(query, columnar=True)
+            # One row per block even if the two parts get merged.
+            inserted = self.client.execute(
+                query, columnar=True, settings={'max_block_size': 1}
+            )
             self.assertEqual(inserted, [(1, 2)])
 
     def test_select_with_column_types(self):


### PR DESCRIPTION

In this PR, we fix both sources of the flaky per-job Coveralls statuses seen on recent PRs.

The first is `test_columnar_block_extend`: it performs two single-row INSERTs so the SELECT streams two blocks and exercises the extension path. If the server happens to merge the two parts before the SELECT, it sends a single block instead. The test still passes, but the extension path goes uncovered. The fix pins `max_block_size=1` on the SELECT.

The second is `SparseSerialization` in `clickhouse_driver/columns/base.py`. Whether blocks are sent in sparse form is the server's choice: on newer servers the existing sparse integration tests receive no sparse blocks at all — against 25.12 the `read_sparse`/`apply_sparse` code never runs. New unit tests feed crafted buffers to the serialization directly, covering every line of it on every job with no server involved. The integration tests stay as they are.
