### PR TITLE
fix: Arrays and tuples incorrectly quoted for server-side parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Native `JSON` support. Solves issue [#473](https://github.com/mymarilyn/clickhouse-driver/issues/473) and [#460](https://github.com/mymarilyn/clickhouse-driver/issues/460). Pull request [#503](https://github.com/mymarilyn/clickhouse-driver/pull/503/) by [khvn26](https://github.com/khvn26), [gsergey418](https://github.com/gsergey418).
 - Minimum `clickhouse-cityhash` version raised to 1.0.2.6: first release that builds on Python 3.13+.
+- Escaping of `list`/`tuple` parameters with `server_side_params=True`: collections were sent in a form the server could not parse. Solves issue [#497](https://github.com/mymarilyn/clickhouse-driver/issues/497). Pull request [#507](https://github.com/mymarilyn/clickhouse-driver/pull/507) by [khvn26](https://github.com/khvn26).
 
 ## [0.2.10] - 2026-10-10
 ### Added

--- a/clickhouse_driver/util/escape.py
+++ b/clickhouse_driver/util/escape.py
@@ -72,7 +72,7 @@ def escape_param(item, context, for_server=False):
         )
         # Server expects the whole collection literal as an escaped
         # string (Field dump format), not a bare [...] or (...).
-        if for_server:
+        if for_server:  # pragma: requires-clickhouse-22.8
             rv = "'%s'" % ''.join(escape_chars_map.get(c, c) for c in rv)
         return rv
 

--- a/clickhouse_driver/util/escape.py
+++ b/clickhouse_driver/util/escape.py
@@ -65,15 +65,16 @@ def escape_param(item, context, for_server=False):
             item = ''.join(escape_chars_map.get(c, c) for c in item)
         return "'%s'" % ''.join(escape_chars_map.get(c, c) for c in item)
 
-    elif isinstance(item, list):
-        return "[%s]" % ', '.join(
-            str(escape_param(x, context, for_server=for_server)) for x in item
+    elif isinstance(item, (list, tuple)):
+        brackets = '[%s]' if isinstance(item, list) else '(%s)'
+        rv = brackets % ', '.join(
+            str(escape_param(x, context)) for x in item
         )
-
-    elif isinstance(item, tuple):
-        return "(%s)" % ', '.join(
-            str(escape_param(x, context, for_server=for_server)) for x in item
-        )
+        # Server expects the whole collection literal as an escaped
+        # string (Field dump format), not a bare [...] or (...).
+        if for_server:
+            rv = "'%s'" % ''.join(escape_chars_map.get(c, c) for c in rv)
+        return rv
 
     elif isinstance(item, Enum):
         return escape_param(item.value, context, for_server=for_server)

--- a/tests/test_substitution.py
+++ b/tests/test_substitution.py
@@ -271,6 +271,50 @@ class ServerSideParametersSubstitutionTestCase(BaseTestCase):
         )
         self.assertEqual(rv, [("'", 1)])
 
+    def test_array(self):
+        rv = self.client.execute(
+            'SELECT {x:Array(String)}', {'x': ['a', 'b', 'c']}
+        )
+        self.assertEqual(rv, [(['a', 'b', 'c'], )])
+
+        rv = self.client.execute(
+            'SELECT {x:Array(UInt8)}', {'x': [1, 2, 3]}
+        )
+        self.assertEqual(rv, [([1, 2, 3], )])
+
+        rv = self.client.execute('SELECT {x:Array(String)}', {'x': []})
+        self.assertEqual(rv, [([], )])
+
+    def test_array_escaped(self):
+        rv = self.client.execute(
+            'SELECT {x:Array(String)}', {'x': ["a'b", 'c\\d', 'e\tf']}
+        )
+        self.assertEqual(rv, [(["a'b", 'c\\d', 'e\tf'], )])
+
+    def test_array_nullable(self):
+        rv = self.client.execute(
+            'SELECT {x:Array(Nullable(String))}', {'x': ['a', None]}
+        )
+        self.assertEqual(rv, [(['a', None], )])
+
+    def test_tuple(self):
+        rv = self.client.execute(
+            'SELECT {x:Tuple(UInt8, String)}', {'x': (1, 'a')}
+        )
+        self.assertEqual(rv, [((1, 'a'), )])
+
+    def test_nested(self):
+        rv = self.client.execute(
+            'SELECT {x:Array(Tuple(UInt8, String))}',
+            {'x': [(1, 'a'), (2, 'b')]}
+        )
+        self.assertEqual(rv, [([(1, 'a'), (2, 'b')], )])
+
+        rv = self.client.execute(
+            'SELECT {x:Array(Array(String))}', {'x': [["a'b"], []]}
+        )
+        self.assertEqual(rv, [([["a'b"], []], )])
+
 
 class NoServerSideParametersSubstitutionTestCase(BaseTestCase):
     def test_reserved_keywords(self):


### PR DESCRIPTION

Fixes #497.

With `server_side_params=True`, any `Array` or `Tuple` parameter fails with `Code: 27. DB::Exception: Cannot parse input: expected ']' at end of stream`, because `escape_param` wraps the already-formatted collection literal in quotes without escaping its contents.

Server-side parameters travel over the native protocol as custom settings, whose values the server parses with `Field::restoreFromDump`. What clickhouse-client sends for an array parameter is a String field containing the SQL literal text of the collection, i.e. the whole literal quoted with inner quotes and backslashes escaped: `'[\'a\', \'b\', \'c\']'`.

This PR does the same: collections are formatted as their SQL literal (elements escaped once, client-side style), then the whole literal is escaped and quoted — mirroring the existing double-escaping of `str` parameters. Scalar parameters are unchanged, as is client-side substitution.

Verified against ClickHouse 25.12 for `Array(String)`, `Array(UInt8)`, empty arrays, elements containing `'`/`\`/tab, `Array(Nullable(String))` with `None`, `Tuple(UInt8, String)`, `Array(Tuple(UInt8, String))` and `Array(Array(String))`. All new tests fail without the fix.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code. (No doc changes needed; the fix makes documented behaviour work. Explanatory comment added in code.)
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
