### PR TITLE
fix: IPv6 column fails to deserialize sparse-serialized data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Native `JSON` support. Solves issue [#473](https://github.com/mymarilyn/clickhouse-driver/issues/473) and [#460](https://github.com/mymarilyn/clickhouse-driver/issues/460). Pull request [#503](https://github.com/mymarilyn/clickhouse-driver/pull/503/) by [khvn26](https://github.com/khvn26), [gsergey418](https://github.com/gsergey418).
 - Minimum `clickhouse-cityhash` version raised to 1.0.2.6: first release that builds on Python 3.13+.
+- Sparse deserialization of `IPv6` columns. Solves issue [#480](https://github.com/mymarilyn/clickhouse-driver/issues/480). Pull request [#508](https://github.com/mymarilyn/clickhouse-driver/pull/508) by [khvn26](https://github.com/khvn26).
 
 ## [0.2.10] - 2026-10-10
 ### Added

--- a/clickhouse_driver/columns/ipcolumn.py
+++ b/clickhouse_driver/columns/ipcolumn.py
@@ -67,6 +67,10 @@ class IPv4Column(UInt32Column):
 class IPv6Column(ByteFixedString):
     ch_type = "IPv6"
     py_types = (str, IPv6Address, bytes)
+    # Wire-format default: must be readable by after_read_items and
+    # writable by write_items as-is (sparse deserialization and
+    # LowCardinality pass it to both without conversion).
+    null_value = b'\x00' * 16
 
     def __init__(self, types_check=False, **kwargs):
         super(IPv6Column, self).__init__(16, types_check=types_check, **kwargs)

--- a/tests/columns/test_sparse.py
+++ b/tests/columns/test_sparse.py
@@ -1,5 +1,6 @@
 from datetime import date
 from io import BytesIO
+from ipaddress import IPv6Address
 from unittest import TestCase
 
 from tests.testcase import BaseTestCase
@@ -101,6 +102,31 @@ class SparseTestCase(BaseTestCase):
                 '1\t(1,(1,0))\n'
                 '0\t(0,(0,0))\n'
                 '0\t(0,(0,0))\n'
+            )
+
+            inserted = self.client.execute(query)
+            self.assertEqual(inserted, data)
+
+    def test_sparse_ipv6(self):
+        columns = 'a IPv6'
+
+        data = [
+            (IPv6Address('::'), ),
+            (IPv6Address('::'), ),
+            (IPv6Address('2001:db8::1'), ),
+        ]
+        with self.create_table(columns):
+            self.client.execute(
+                'INSERT INTO test VALUES', data
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(
+                inserted,
+                '::\n'
+                '::\n'
+                '2001:db8::1\n'
             )
 
             inserted = self.client.execute(query)


### PR DESCRIPTION

Fixes #480.

`IPv6Column` inherits `null_value = b''` from `ByteFixedString`. When the server sends a sparse-serialized IPv6 column, we pass that null value, which results in an `AddressValueError`.

In this PR, we set `IPv6Column.null_value` to the 16-byte zero address. We prefer it to the `::` because `apply_sparse` and `LowCardinalityColumn._write_data` consume it directly without any conversion.

The new `test_sparse_ipv6` test fails with the `AddressValueError` above without the fix and passes with it. The full suite run against ClickHouse 24.8.14.39 on my macOS machine shows no regressions.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
