### PR TITLE
ci: Avoid GHA run spam for PRs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,15 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+    tags: ['*']
+  pull_request:
 name: build
+
+concurrency:
+  # One lane per workflow + PR; non-PR pushes fall back to run_id (never cancel each other)
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,15 @@
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+    tags: ['*']
+  pull_request:
 name: build-docs
+
+concurrency:
+  # One lane per workflow + PR; non-PR pushes fall back to run_id (never cancel each other)
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-22.04


### PR DESCRIPTION

In this PR, we add concurrency groups to PR-triggered actions. Runs triggered by pushes to the main branch stay as they were; only PR branches are affected.
