### PR TITLE
Nested JSON writes support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Native `JSON` support. Solves issue [#473](https://github.com/mymarilyn/clickhouse-driver/issues/473) and [#460](https://github.com/mymarilyn/clickhouse-driver/issues/460). Pull request [#503](https://github.com/mymarilyn/clickhouse-driver/pull/503/) by [khvn26](https://github.com/khvn26), [gsergey418](https://github.com/gsergey418).
+- Writing `JSON` columns nested in `Array`, `Tuple` and `Map` columns. Solves issue [#511](https://github.com/mymarilyn/clickhouse-driver/issues/511).
 - Minimum `clickhouse-cityhash` version raised to 1.0.2.6: first release that builds on Python 3.13+.
 
 ## [0.2.10] - 2026-10-10

--- a/clickhouse_driver/columns/arraycolumn.py
+++ b/clickhouse_driver/columns/arraycolumn.py
@@ -34,6 +34,7 @@ class ArrayColumn(Column):
         self._write_depth_0_size = True
         super(ArrayColumn, self).__init__(**kwargs)
         self.null_value = []
+        self.prefix_needs_items = nested_column.prefix_needs_items
 
     def write_data(self, data, buf):
         # Column of Array(T) is stored in "compact" format and passed to server
@@ -115,10 +116,17 @@ class ArrayColumn(Column):
 
         self.nested_column.read_state_prefix(buf)
 
-    def write_state_prefix(self, buf):
+    def write_state_prefix(self, buf, items=None):
         super(ArrayColumn, self).write_state_prefix(buf)
 
-        self.nested_column.write_state_prefix(buf)
+        nested_items = None
+        if items is not None and self.nested_column.prefix_needs_items:
+            # One level of flattening per Array level, so the leaf
+            # column sees the same flat item list its data writer will
+            # receive.
+            nested_items = [x for item in items if item is not None
+                            for x in item]
+        self.nested_column.write_state_prefix(buf, nested_items)
 
     def _read(self, size, buf):
         slices_series = [[0, size]]

--- a/clickhouse_driver/columns/base.py
+++ b/clickhouse_driver/columns/base.py
@@ -70,6 +70,12 @@ class Column(object):
 
     null_value = 0
 
+    # True when ``write_state_prefix`` needs the block's items to emit
+    # the prefix (JSON: the path list is data-dependent). Container
+    # columns propagate the flag and thread flattened items through so
+    # ordinary columns never pay for the flattening.
+    prefix_needs_items = False
+
     def __init__(self, types_check=False, has_custom_serialization=False,
                  **kwargs):
         self.nullable = False
@@ -183,7 +189,7 @@ class Column(object):
             if use_custom_serialization:
                 self.serialization = SparseSerialization(self)
 
-    def write_state_prefix(self, buf):
+    def write_state_prefix(self, buf, items=None):
         pass
 
 

--- a/clickhouse_driver/columns/jsoncolumn.py
+++ b/clickhouse_driver/columns/jsoncolumn.py
@@ -16,7 +16,7 @@ class JsonColumn(Column):
         self.string_column = String(**kwargs)
         super(JsonColumn, self).__init__(**kwargs)
 
-    def write_state_prefix(self, buf):
+    def write_state_prefix(self, buf, items=None):
         # Read in binary format.
         # Write in text format.
         write_binary_uint8(1, buf)

--- a/clickhouse_driver/columns/lowcardinalitycolumn.py
+++ b/clickhouse_driver/columns/lowcardinalitycolumn.py
@@ -44,7 +44,7 @@ class LowCardinalityColumn(Column):
 
         read_binary_uint64(buf)
 
-    def write_state_prefix(self, buf):
+    def write_state_prefix(self, buf, items=None):
         super(LowCardinalityColumn, self).write_state_prefix(buf)
 
         # KeysSerializationVersion. See ClickHouse docs.

--- a/clickhouse_driver/columns/mapcolumn.py
+++ b/clickhouse_driver/columns/mapcolumn.py
@@ -17,6 +17,10 @@ class MapColumn(Column):
         self.key_column = key_column
         self.value_column = value_column
         super(MapColumn, self).__init__(**kwargs)
+        self.prefix_needs_items = (
+            key_column.prefix_needs_items or
+            value_column.prefix_needs_items
+        )
 
     def read_state_prefix(self, buf):
         super(MapColumn, self).read_state_prefix(buf)
@@ -24,11 +28,16 @@ class MapColumn(Column):
         self.key_column.read_state_prefix(buf)
         self.value_column.read_state_prefix(buf)
 
-    def write_state_prefix(self, buf):
+    def write_state_prefix(self, buf, items=None):
         super(MapColumn, self).write_state_prefix(buf)
 
-        self.key_column.write_state_prefix(buf)
-        self.value_column.write_state_prefix(buf)
+        key_items = value_items = None
+        if items is not None and self.key_column.prefix_needs_items:
+            key_items = [k for x in items for k in x]
+        if items is not None and self.value_column.prefix_needs_items:
+            value_items = [v for x in items for v in x.values()]
+        self.key_column.write_state_prefix(buf, key_items)
+        self.value_column.write_state_prefix(buf, value_items)
 
     def read_items(self, n_items, buf):
         if not n_items:

--- a/clickhouse_driver/columns/mapcolumn.py
+++ b/clickhouse_driver/columns/mapcolumn.py
@@ -17,10 +17,9 @@ class MapColumn(Column):
         self.key_column = key_column
         self.value_column = value_column
         super(MapColumn, self).__init__(**kwargs)
-        self.prefix_needs_items = (
-            key_column.prefix_needs_items or
-            value_column.prefix_needs_items
-        )
+        # Map keys are restricted to scalar types, so only the value
+        # column can carry a data-dependent prefix.
+        self.prefix_needs_items = value_column.prefix_needs_items
 
     def read_state_prefix(self, buf):
         super(MapColumn, self).read_state_prefix(buf)
@@ -31,12 +30,10 @@ class MapColumn(Column):
     def write_state_prefix(self, buf, items=None):
         super(MapColumn, self).write_state_prefix(buf)
 
-        key_items = value_items = None
-        if items is not None and self.key_column.prefix_needs_items:
-            key_items = [k for x in items for k in x]
+        value_items = None
         if items is not None and self.value_column.prefix_needs_items:
             value_items = [v for x in items for v in x.values()]
-        self.key_column.write_state_prefix(buf, key_items)
+        self.key_column.write_state_prefix(buf)
         self.value_column.write_state_prefix(buf, value_items)
 
     def read_items(self, n_items, buf):

--- a/clickhouse_driver/columns/newjsoncolumn.py
+++ b/clickhouse_driver/columns/newjsoncolumn.py
@@ -56,12 +56,19 @@ class NewJsonColumn(Column):  # pragma: requires-clickhouse-24.8
     shared data rather than hand-rolled.
     """
 
-    py_types = (dict, )
+    py_types = (dict, str)
 
     # JSON columns are non-nullable on the wire; supply an empty dict
     # as the placeholder used by sparse/null helpers in the base
     # column.
     null_value = {}
+
+    # The object prefix (path list + per-path SerializationDynamic
+    # prefixes) is data-dependent; ``write_column`` and the container
+    # columns (Array/Tuple/Map) thread the block's items into
+    # ``write_state_prefix`` so it lands in the prefix stream position
+    # the server expects for nested columns.
+    prefix_needs_items = True
 
     def __init__(self, column_by_spec_getter, **kwargs):
         self.column_by_spec_getter = column_by_spec_getter
@@ -69,6 +76,7 @@ class NewJsonColumn(Column):  # pragma: requires-clickhouse-24.8
         self.string_column = String(**kwargs)
 
         self.serialization_version = None
+        self._write_paths_state = None
         self.sorted_dynamic_paths = []
         self.dynamic_columns = []
         self.shared_data_column = None
@@ -204,27 +212,23 @@ class NewJsonColumn(Column):  # pragma: requires-clickhouse-24.8
     # write path
     # ------------------------------------------------------------------
 
-    def write_state_prefix(self, buf):
-        # The JSON column's state prefix is data-dependent (path list +
-        # per-path SerializationDynamic prefixes), so we cannot emit it
-        # here — items are only available once ``write_data`` is
-        # called. Emitting the full prefix inside ``write_data`` also
-        # lets the nulls map written by the base ``Column.write_data``
-        # for ``Nullable(JSON)`` land between the prefix and the body,
-        # matching the on-wire order the server expects.
-        pass
-
-    def write_data(self, items, buf, depth=0):
-        # ``_write_nulls_map`` keys off ``x is None``, so it has to see
-        # the original items before ``None`` is coerced to
-        # ``null_value`` for the body writer.
-        original_items = items if self.nullable else None
+    def write_state_prefix(self, buf, items=None):
+        if items is None:
+            raise NotImplementedError(
+                'JSON columns can only be written when the block items '
+                'are threaded into write_state_prefix'
+            )
         items = [self._normalise_write_item(x) for x in items]
-        paths = self._unfold_json(items, depth)
-        self._write_object_state_prefix(paths, buf, depth=depth)
-        if self.nullable:
-            self._write_nulls_map(original_items, buf)
-        self._write_values(paths, len(items), buf, depth=depth)
+        self._write_paths_state = self._unfold_json(items, depth=0)
+        self._write_object_state_prefix(self._write_paths_state, buf)
+
+    def write_items(self, items, buf):
+        # The body is written from the paths computed over the same
+        # items in ``write_state_prefix``; ``items`` only supplies the
+        # row count here. For ``Nullable(JSON)`` the nulls map emitted
+        # by the callers lands between the prefix and this body,
+        # matching the on-wire order the server expects.
+        self._write_values(self._write_paths_state, len(items), buf)
 
     def _normalise_write_item(self, item):
         if item is None:

--- a/clickhouse_driver/columns/service.py
+++ b/clickhouse_driver/columns/service.py
@@ -169,7 +169,7 @@ def write_column(context, column_name, column_spec, items, buf,
     column = get_column_by_spec(column_spec, column_options)
 
     try:
-        column.write_state_prefix(buf)
+        column.write_state_prefix(buf, items)
         column.write_data(items, buf)
 
     except column_exceptions.ColumnTypeMismatchException as e:

--- a/clickhouse_driver/columns/tuplecolumn.py
+++ b/clickhouse_driver/columns/tuplecolumn.py
@@ -18,6 +18,9 @@ class TupleColumn(Column):
 
         super(TupleColumn, self).__init__(**kwargs)
         self.null_value = tuple(x.null_value for x in nested_columns)
+        self.prefix_needs_items = any(
+            x.prefix_needs_items for x in nested_columns
+        )
 
     def write_data(self, items, buf):
         items = self.prepare_items(items)
@@ -47,11 +50,14 @@ class TupleColumn(Column):
         for x in self.nested_columns:
             x.read_state_prefix(buf)
 
-    def write_state_prefix(self, buf):
+    def write_state_prefix(self, buf, items=None):
         super(TupleColumn, self).write_state_prefix(buf)
 
-        for x in self.nested_columns:
-            x.write_state_prefix(buf)
+        for i, x in enumerate(self.nested_columns):
+            nested_items = None
+            if items is not None and x.prefix_needs_items:
+                nested_items = [item[i] for item in items]
+            x.write_state_prefix(buf, nested_items)
 
 
 def create_tuple_column(spec, column_by_spec_getter, column_options):

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -506,8 +506,12 @@ JSON
 
 *New in version 0.2.11.*
 
-INSERT types: :class:`dict`.
+INSERT types: :class:`dict`, :class:`str` (JSON text).
 
 SELECT type: :class:`dict`, :class:`str`.
 
 Set ``enable_json_type=1`` for to enable json support.
+
+``JSON`` columns nested in container columns, e.g. ``Array(JSON)``,
+``Tuple(String, JSON)``, ``Map(String, JSON)`` and their compositions, can
+be written and read as well.

--- a/tests/columns/test_newjson.py
+++ b/tests/columns/test_newjson.py
@@ -1,4 +1,11 @@
+from io import BytesIO
+from unittest import TestCase
+
 from tests.testcase import BaseTestCase
+from clickhouse_driver.bufferedreader import CompressedBufferedReader
+from clickhouse_driver.bufferedwriter import CompressedBufferedWriter
+from clickhouse_driver.columns.service import read_column, write_column
+from clickhouse_driver.context import Context
 
 
 class NewJSONTestCase(BaseTestCase):
@@ -1151,3 +1158,86 @@ class JSONInContainerColumnsTestCase(BaseTestCase):
             self.client.execute("INSERT INTO test (a) VALUES", data)
             result = self.client.execute("SELECT * FROM test")
             self.assertEqual(result, data)
+
+
+class JSONWireRoundTripTestCase(TestCase):
+    # Which server versions run the integration tests above is a matrix
+    # choice, so the JSON write path would go uncovered on jobs against
+    # servers without JSON support. Serialize and deserialize a block
+    # locally so every line is exercised deterministically on every
+    # job. Wire compatibility itself is covered by the server-backed
+    # tests.
+
+    def make_context(self):
+        context = Context()
+        context.client_settings = {
+            'use_numpy': False,
+            'strings_as_bytes': False,
+        }
+        context.settings = {}
+        return context
+
+    def round_trip(self, spec, items):
+        context = self.make_context()
+
+        sink = BytesIO()
+        write_buf = CompressedBufferedWriter(sink, 1024)
+        # prepare_items mutates the list it is given (e.g. None ->
+        # null_value); write a copy so `items` stays comparable.
+        write_column(context, 'a', spec, list(items), write_buf)
+        write_buf.flush()
+
+        chunks = [sink.getvalue()]
+        read_buf = CompressedBufferedReader(
+            lambda: chunks.pop() if chunks else b'', 1024)
+        return list(read_column(context, spec, len(items), read_buf))
+
+    def test_json(self):
+        items = [
+            {'i': 1, 'f': 2.5, 's': 'x', 'b': True, 'n': {'d': 'deep'}},
+            {'list': [1, 2], 'strings': ['a', 'b']},
+            {},
+        ]
+        self.assertEqual(self.round_trip('JSON', items), items)
+
+    def test_nullable_json(self):
+        items = [None, {'x': 1}, None]
+        self.assertEqual(self.round_trip('Nullable(JSON)', items), items)
+
+    def test_map_of_json(self):
+        items = [
+            {'k': {'a': 1}, 'j': {'b': 'x'}},
+            {},
+            {'empty': {}},
+        ]
+        self.assertEqual(self.round_trip('Map(String, JSON)', items), items)
+
+    def test_array_of_json(self):
+        items = [
+            [{'a': 1}, {'b': 'x'}],
+            [],
+        ]
+        self.assertEqual(self.round_trip('Array(JSON)', items), items)
+
+    def test_array_of_nullable_json(self):
+        items = [[{'a': 1}, None]]
+        self.assertEqual(
+            self.round_trip('Array(Nullable(JSON))', items), items)
+
+    def test_tuple_with_json(self):
+        items = [('s1', {'a': 1}), ('s2', {'b': 2})]
+        self.assertEqual(
+            self.round_trip('Tuple(String, JSON)', items), items)
+
+    def test_map_of_array_of_json(self):
+        items = [{'k': [{'a': 1}], 'l': [{'b': 2}, {'c': 3}]}]
+        self.assertEqual(
+            self.round_trip('Map(String, Array(JSON))', items), items)
+
+    def test_write_state_prefix_requires_items(self):
+        from clickhouse_driver.columns.service import get_column_by_spec
+
+        column = get_column_by_spec(
+            'JSON', {'context': self.make_context()}, use_numpy=False)
+        with self.assertRaises(NotImplementedError):
+            column.write_state_prefix(BytesIO(), None)

--- a/tests/columns/test_newjson.py
+++ b/tests/columns/test_newjson.py
@@ -1073,7 +1073,12 @@ class JSONInContainerColumnsTestCase(BaseTestCase):
             self.client.execute(
                 "INSERT INTO test (a) VALUES",
                 [({"k": {"a": 1, "n": {"d": "deep"}}},)])
-            cli = self.emit_cli("SELECT toJSONString(a) FROM test")
+            # Integer quoting in JSON output defaults differently across
+            # server versions; pin it so the assertion is stable.
+            cli = self.emit_cli(
+                "SELECT toJSONString(a) FROM test",
+                output_format_json_quote_64bit_integers=0,
+            )
             self.assertEqual(cli, '{"k":{"a":1,"n":{"d":"deep"}}}\n')
 
     def test_map_of_json_string_value_input(self):

--- a/tests/columns/test_newjson.py
+++ b/tests/columns/test_newjson.py
@@ -1034,3 +1034,115 @@ class NewJSONTestCase(BaseTestCase):
                 ({"items": [{"p": 1}, {"q": "x"}]},),
                 ({"items": [{"nested": {"deep": 5}}]},),
             ])
+
+
+class JSONInContainerColumnsTestCase(BaseTestCase):
+    """
+    JSON columns nested inside container column types. The object
+    prefix is data-dependent, so the write path threads the block's
+    items into ``write_state_prefix`` to emit it in the prefix stream
+    position the server expects for nested columns; inserts into
+    ``Map(String, JSON)`` used to deadlock and ``Array(JSON)`` raised
+    ``NotImplementedError`` (issue #511).
+    """
+
+    required_server_version = (24, 8, 0)
+
+    def client_kwargs(self, version):
+        return {"settings": {"enable_json_type": True}}
+
+    def cli_client_kwargs(self):
+        return {"enable_json_type": 1}
+
+    def test_map_of_json(self):
+        with self.create_table("a Map(String, JSON)"):
+            data = [
+                ({"k": {"a": 1}},),
+                ({"k": {"b": "x"}, "j": {"c": 2.5, "d": {"e": True}}},),
+                ({},),
+                ({"empty": {}},),
+            ]
+            self.client.execute("INSERT INTO test (a) VALUES", data)
+            result = self.client.execute("SELECT * FROM test")
+            self.assertEqual(result, data)
+
+    def test_map_of_json_server_side_view(self):
+        # The CLI view proves the bytes landed correctly on the server,
+        # not just that the client can read back its own encoding.
+        with self.create_table("a Map(String, JSON)"):
+            self.client.execute(
+                "INSERT INTO test (a) VALUES",
+                [({"k": {"a": 1, "n": {"d": "deep"}}},)])
+            cli = self.emit_cli("SELECT toJSONString(a) FROM test")
+            self.assertEqual(cli, '{"k":{"a":1,"n":{"d":"deep"}}}\n')
+
+    def test_map_of_json_string_value_input(self):
+        # JSON given as text is parsed by the write path, same as for
+        # top-level JSON columns.
+        with self.create_table("a Map(String, JSON)"):
+            self.client.execute(
+                "INSERT INTO test (a) VALUES", [({"k": '{"s": 1}'},)])
+            result = self.client.execute("SELECT * FROM test")
+            self.assertEqual(result, [({"k": {"s": 1}},)])
+
+    def test_array_of_json(self):
+        with self.create_table("a Array(JSON)"):
+            data = [
+                ([{"a": 1}, {"b": "x"}],),
+                ([],),
+                ([{"c": [1, 2, 3]}],),
+            ]
+            self.client.execute("INSERT INTO test (a) VALUES", data)
+            result = self.client.execute("SELECT * FROM test")
+            self.assertEqual(result, data)
+
+    def test_tuple_with_json(self):
+        with self.create_table("a Tuple(String, JSON)"):
+            data = [
+                (("s1", {"a": 1}),),
+                (("s2", {"b": {"c": "deep"}}),),
+            ]
+            self.client.execute("INSERT INTO test (a) VALUES", data)
+            result = self.client.execute("SELECT * FROM test")
+            self.assertEqual(result, data)
+
+    def test_map_of_array_of_json(self):
+        with self.create_table("a Map(String, Array(JSON))"):
+            data = [
+                ({"k": [{"a": 1}], "l": [{"b": 2}, {"c": 3}]},),
+                ({},),
+            ]
+            self.client.execute("INSERT INTO test (a) VALUES", data)
+            result = self.client.execute("SELECT * FROM test")
+            self.assertEqual(result, data)
+
+    def test_array_of_array_of_json(self):
+        with self.create_table("a Array(Array(JSON))"):
+            data = [
+                ([[{"a": 1}], [{"b": 2}, {"c": 3}]],),
+                ([[]],),
+            ]
+            self.client.execute("INSERT INTO test (a) VALUES", data)
+            result = self.client.execute("SELECT * FROM test")
+            self.assertEqual(result, data)
+
+    def test_map_of_nullable_json(self):
+        with self.create_table("a Map(String, Nullable(JSON))"):
+            data = [({"k": {"a": 1}, "n": None},)]
+            self.client.execute("INSERT INTO test (a) VALUES", data)
+            result = self.client.execute("SELECT * FROM test")
+            self.assertEqual(result, data)
+
+    def test_array_of_nullable_json(self):
+        with self.create_table("a Array(Nullable(JSON))"):
+            data = [([{"a": 1}, None, {"b": 2}],)]
+            self.client.execute("INSERT INTO test (a) VALUES", data)
+            result = self.client.execute("SELECT * FROM test")
+            self.assertEqual(result, data)
+
+    def test_map_of_map_of_json(self):
+        with self.create_table("a Map(String, Map(String, JSON))"):
+            data = [({"outer": {"inner": {"a": 1}}},)]
+            self.client.execute("INSERT INTO test (a) VALUES", data)
+            result = self.client.execute("SELECT * FROM test")
+            self.assertEqual(result, data)


### PR DESCRIPTION

Fixes #511.

In this PR, we add write support for `JSON` columns nested inside container columns and their compositions.

We're adding an optional `items` parameter to `Column.write_state_prefix`. This aligns with server-side protocol implementation which does allow prefixes to be data-dependent (ClickHouse v22.11, November 2022). The first consumer is `NewJsonColumn`.

We also add a `prefix_needs_items` flag to signal container columns to flatten items one level per container on the way down, so columns without a data-dependent prefix pay nothing.

Verified against ClickHouse 25.12.11.4, including a cross-check reading driver-inserted data back through `clickhouse-client`, multi-block inserts, and JSON-given-as-text values.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Ensure PR doesn't contain untouched code reformatting: spaces, etc.
- [x] Run `flake8` and fix issues.
- [x] Run `pytest` no tests failed. See https://clickhouse-driver.readthedocs.io/en/latest/development.html.
