### PR TITLE
Fix Bool column deserialization for sparse-serialized default values

### DIFF
--- a/clickhouse_driver/columns/boolcolumn.py
+++ b/clickhouse_driver/columns/boolcolumn.py
@@ -5,3 +5,4 @@ class BoolColumn(FormatColumn):
     ch_type = 'Bool'
     py_types = (bool, )
     format = '?'
+    null_value = False

--- a/tests/columns/test_sparse.py
+++ b/tests/columns/test_sparse.py
@@ -6,6 +6,8 @@ from unittest import TestCase
 from tests.testcase import BaseTestCase
 from clickhouse_driver import errors
 from clickhouse_driver.columns.base import SparseSerialization
+from clickhouse_driver.columns.boolcolumn import BoolColumn
+from clickhouse_driver.context import Context
 from clickhouse_driver.varint import write_varint
 
 ErrorCodes = errors.ErrorCodes
@@ -155,6 +157,25 @@ class SparseTestCase(BaseTestCase):
             inserted = self.client.execute(query)
             self.assertEqual(inserted, data)
 
+    def test_sparse_bool(self):
+        columns = 'a Bool'
+
+        data = [(True, ), (False, ), (False, ), (False, )]
+        with self.create_table(columns):
+            self.client.execute(
+                'INSERT INTO test (a) VALUES', data
+            )
+
+            query = 'SELECT * FROM test'
+            inserted = self.emit_cli(query)
+            self.assertEqual(inserted, 'true\nfalse\nfalse\nfalse\n')
+
+            inserted = self.client.execute(query)
+            self.assertEqual(inserted, data)
+            # 0 == False in Python: check types explicitly.
+            for (value, ) in inserted:
+                self.assertIsInstance(value, bool)
+
 
 class FakeColumn(object):
     null_value = 0
@@ -200,3 +221,25 @@ class SparseSerializationTestCase(TestCase):
 
         self.assertEqual(n_items, 1)
         self.assertEqual(serialization.apply_sparse([105]), [105, 100])
+
+    def test_apply_sparse_bool_returns_real_bools(self):
+        # Default positions are filled with Column.null_value. BoolColumn
+        # used to inherit the int 0, yielding [0, 0, True, ...] instead of
+        # [False, False, True, ...]. assertEqual alone cannot catch this
+        # since 0 == False in Python: check types explicitly.
+        context = Context()
+        context.client_settings = {'input_format_null_as_default': False}
+        serialization = SparseSerialization(BoolColumn(context=context))
+
+        # Non-default items at positions 3 and 7 of 8 items.
+        buf = self.make_buf([2, 3, self.END_OF_GRANULE_FLAG | 1])
+        n_items = serialization.read_sparse(8, buf)
+        self.assertEqual(n_items, 2)
+
+        result = serialization.apply_sparse([True, True])
+        self.assertEqual(
+            result,
+            [False, False, True, False, False, False, True, False]
+        )
+        for value in result:
+            self.assertIsInstance(value, bool)


### PR DESCRIPTION
**This pull request has been developed by Claude and reviewed by me after some deep analysis of our codebase.**

Fixes #514.

**Problem**

When a `Bool` column is stored using sparse serialization, its default (most frequent) values are deserialized as the Python `int` `0` instead of `False`.

`SparseSerialization.apply_sparse` (in `columns/base.py`) fills the default positions with `self.column.null_value`, and `BoolColumn` inherits the generic `null_value = 0` from the base `Column` without overriding it (and has no `after_read_items` to convert the default back). As a result a sparse-serialized `Bool` column comes back as a mix of `int` (default positions) and `bool` (explicit values), e.g. `[0, 0, True, 0, True]` instead of `[False, False, True, False, True]`.

This is the same bug family as #480, fixed for `IPv6` in #508.

**Fix**

Give `BoolColumn` a boolean `null_value` so `apply_sparse` fills defaults with the correct type:

```python
class BoolColumn(FormatColumn):
    ch_type = 'Bool'
    py_types = (bool, )
    format = '?'
    null_value = False
```

The write path is unchanged: `struct.pack('?', False)` and `struct.pack('?', 0)` produce the same byte (`b'\x00'`), so nullable/`input_format_null_as_default`/`LowCardinality` placeholders are byte-identical on the wire. The numpy path is unaffected (`NumpyBoolColumn` is a separate class). The only observable difference is that sparse-serialized `Bool` values are now returned as real `bool`.

**Tests**

Added to `tests/columns/test_sparse.py`, mirroring the IPv6 test from #508:

- `test_apply_sparse_bool_returns_real_bools`: unit test of `SparseSerialization` against `BoolColumn` (no server required). Fails on `master` (`0 is not an instance of bool`) and passes with the fix. Note that `assertEqual` alone is not enough since `0 == False` in Python, so element types are checked explicitly.
- `test_sparse_bool`: integration test on a table created with `ratio_of_defaults_for_sparse_serialization = 0.5`.
